### PR TITLE
Version 1.19

### DIFF
--- a/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
@@ -54,88 +54,88 @@ GVAR(locations_west) =
     [[3003,0,18176], "Marine Basis", 0],
     [[8570,0,7349], "FOB", 0],
 
-       [[4925.6323,341.19653,21895.656], "1 - Throns castel",1], // 1 - Throns_castel
-	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",1], // 2 - Oreokastro
-	   [[4910.3472,197.1022,19458.254], "3 - Waffenlager Nord West",1], // 3 - Waffenlager_Nord_West
-	   [[3360.3782,67.56945,18310.93], "4 - Villa Constans",1], // 4 - Villa_Constans
+       [[4925.6323,341.19653,21895.656], "1 - Throns castel",0], // 1 - Throns_castel
+	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",0], // 2 - Oreokastro
+	   [[4910.3472,197.1022,19458.254], "3 - Waffenlager Nord West",0], // 3 - Waffenlager_Nord_West
+	   [[3360.3782,67.56945,18310.93], "4 - Villa Constans",0], // 4 - Villa_Constans
 
-	   [[5410.8721,76.737549,17909.359], "5 - Mine Gore",1], // 5 - Mine_Gore
-	   [[6181.8838,43.000999,16256.253], "6 - Kore Fabrik",1], // 6 - Kore_Fabrik
-	   [[4267.708,28.040495,13902.733], "7 - Checkpoint charlie",1], // 7 - Checkpoint_charlie
-	   [[3723.6956,18.555311,12999.2], "8 - Kavala Hospital",1], // 8 - Kavala_Hospital
+	   [[5410.8721,76.737549,17909.359], "5 - Mine Gore",0], // 5 - Mine_Gore
+	   [[6181.8838,43.000999,16256.253], "6 - Kore Fabrik",0], // 6 - Kore_Fabrik
+	   [[4267.708,28.040495,13902.733], "7 - Checkpoint charlie",0], // 7 - Checkpoint_charlie
+	   [[3723.6956,18.555311,12999.2], "8 - Kavala Hospital",0], // 8 - Kavala_Hospital
 
-	   [[5940.9346,101.7437,12461.137], "9 - Lager Panagiotis",1], // 9 - Lager_Panagiotis
-	   [[7233.4165,4.3041649,11030.594], "10 - Edessa",1], // 10 - Edessa
-	   [[9684.7617,3.5207906,22269.395], "11 - Krya Nera",1], // 11 - Krya_Nera
-	   [[8532.0986,68.093964,20879.943], "12 - Abdera Farm",1], // 12 - Abdera_Farm
+	   [[5940.9346,101.7437,12461.137], "9 - Lager Panagiotis",0], // 9 - Lager_Panagiotis
+	   [[7233.4165,4.3041649,11030.594], "10 - Edessa",0], // 10 - Edessa
+	   [[9684.7617,3.5207906,22269.395], "11 - Krya Nera",0], // 11 - Krya_Nera
+	   [[8532.0986,68.093964,20879.943], "12 - Abdera Farm",0], // 12 - Abdera_Farm
 	   
-	   [[9410.1563,118.25887,20300.502], "13 - Abdera Rathaus",1], // 13 - Abdera_Rathaus
-	   [[10405.196,120.67762,19023.145], "14 - Galati alte Post",1], // 14 - Galati_alte_Post
-	   [[7533.3193,134.73981,18346.297], "15 - Enclave Syrta",1], // 15 - Enclave_Syrta
+	   [[9410.1563,118.25887,20300.502], "13 - Abdera Rathaus",0], // 13 - Abdera_Rathaus
+	   [[10405.196,120.67762,19023.145], "14 - Galati alte Post",0], // 14 - Galati_alte_Post
+	   [[7533.3193,134.73981,18346.297], "15 - Enclave Syrta",0], // 15 - Enclave_Syrta
 
-	   [[7111.4897,111.96675,16438.803], "16 - Kore Zentrum",1], // 16 - Kore_Zentrum
-	   [[9196.6797,120.77501,15821.593], "17 - Checkpoint Agios Dionisos",1], // 17 - Checkpoint Agios Dionisos
-	   [[9301.5342,30.298265,13664.528], "18 - Xirolimni Damm",1], // 18 - Xirolimni_Damm",1
+	   [[7111.4897,111.96675,16438.803], "16 - Kore Zentrum",0], // 16 - Kore_Zentrum
+	   [[9196.6797,120.77501,15821.593], "17 - Checkpoint Agios Dionisos",0], // 17 - Checkpoint Agios Dionisos
+	   [[9301.5342,30.298265,13664.528], "18 - Xirolimni Damm",0], // 18 - Xirolimni_Damm",1
 	   
-	   [[9468.4805,26.262537,8236.5488], "19 - Hühnerfarm Sfaka",1], // 19 - Hühnerfarm_Sfaka
+	   [[9468.4805,26.262537,8236.5488], "19 - Hühnerfarm Sfaka",0], // 19 - Hühnerfarm_Sfaka
 
-	   [[12318.005,20.195953,22856.318], "20 - Tonos Bucht",1], // 20 - Tonos_Bucht
-	   [[13013.089,32.230129,19448.695], "21 - Checkpoint Ifestonia",1], // Checkpoint_Ifestonia
-	   [[12672.666,34.210361,16390.48], "22 - Lacca Fabrik",1], // 22 - Lacca_Fabrik
+	   [[12318.005,20.195953,22856.318], "20 - Tonos Bucht",0], // 20 - Tonos_Bucht
+	   [[13013.089,32.230129,19448.695], "21 - Checkpoint Ifestonia",0], // Checkpoint_Ifestonia
+	   [[12672.666,34.210361,16390.48], "22 - Lacca Fabrik",0], // 22 - Lacca_Fabrik
 
-	   [[13248.13,13.200888,14947.823], "23 - Stavros Radar",1], // 23 - Stavros_Radar
-	   [[12151.891,9.668313,14330.698], "24 - Neochori Wollmarkt",1], // 24 - Neochori_Wollmarkt
-	   [[11105.64,19.684849,13325.393], "25 - Poliakko alte Brennerei",1], // 25 - Poliakko_alte_Brennerei
+	   [[13248.13,13.200888,14947.823], "23 - Stavros Radar",0], // 23 - Stavros_Radar
+	   [[12151.891,9.668313,14330.698], "24 - Neochori Wollmarkt",0], // 24 - Neochori_Wollmarkt
+	   [[11105.64,19.684849,13325.393], "25 - Poliakko alte Brennerei",0], // 25 - Poliakko_alte_Brennerei
 	   
-	   [[10675.173,16.757935,12266.578], "26 - Therisa Markt",1], // 26 - Therisa_Markt
-	   [[10819.854,6.4413772,10859.053], "27 - Drimea Fährstation",1], // 27 - Drimea_Fährstation
-	   [[11562.51,77.303802,7045.9185], "28 - Egino Farmhaus",1], // 28 - Egino_Farmhaus
+	   [[10675.173,16.757935,12266.578], "26 - Therisa Markt",0], // 26 - Therisa_Markt
+	   [[10819.854,6.4413772,10859.053], "27 - Drimea Fährstation",0], // 27 - Drimea_Fährstation
+	   [[11562.51,77.303802,7045.9185], "28 - Egino Farmhaus",0], // 28 - Egino_Farmhaus
   
-	   [[14266.871,43.789253,22215.367], "29 - Hanf Plantage Frini",1], // 29 - Hanf_Plantage_Frini 
-	   [[14716.515,46.701706,20735.465], "30 - Frini Polizeistation",1], // 30 - Frini_Polizeistation
-	   [[14320.399,36.900391,18909.221], "31 - Athira Factory",1], // 31 - Athira_Factory
+	   [[14266.871,43.789253,22215.367], "29 - Hanf Plantage Frini",0], // 29 - Hanf_Plantage_Frini 
+	   [[14716.515,46.701706,20735.465], "30 - Frini Polizeistation",0], // 30 - Frini_Polizeistation
+	   [[14320.399,36.900391,18909.221], "31 - Athira Factory",0], // 31 - Athira_Factory
 	   
-	   [[14937.858,17.528454,17153.338], "32 - Airbase Altis",1], // 32 - Airbase_Altis
-	   [[13589.743,16.363777,12166.921], "33 - xxxxxxxxxxxxx",1], // 33 - xxxxxxxxxxxxx
-	   [[11908.478,15.18861,9707.3877], "34 - Alpaka Residenz",1], // 34 - Alpaka_Residenz
+	   [[14937.858,17.528454,17153.338], "32 - Airbase Altis",0], // 32 - Airbase_Altis
+	   [[13589.743,16.363777,12166.921], "33 - xxxxxxxxxxxxx",0], // 33 - xxxxxxxxxxxxx
+	   [[11908.478,15.18861,9707.3877], "34 - Alpaka Residenz",0], // 34 - Alpaka_Residenz
 	   
-	   [[16587.895,35.317459,19002.33], "35 - Kalithea Kontrolltower",1], // 35 - Kalithea_Kontrolltower
+	   [[16587.895,35.317459,19002.33], "35 - Kalithea Kontrolltower",0], // 35 - Kalithea_Kontrolltower
 	   
-	   [[16451.031,24.131969,17237.797], "36 - Thelos Zentrum",1], // 36 - Thelos_Zentrum
-	   [[16681.539,18.231377,16143.08], "37 - Athira Kirchplatz",1], // 37 - Athira_Kirchplatz
-	   [[16703.346,10.311413,13522.601], "38 - xxxxxxxxxxx",1], // 38 _ xxxxxxxxxxxxxx
+	   [[16451.031,24.131969,17237.797], "36 - Thelos Zentrum",0], // 36 - Thelos_Zentrum
+	   [[16681.539,18.231377,16143.08], "37 - Athira Kirchplatz",0], // 37 - Athira_Kirchplatz
+	   [[16703.346,10.311413,13522.601], "38 - xxxxxxxxxxx",0], // 38 _ xxxxxxxxxxxxxx
 
 	   [[16611.455,13.550769,12640.338], "39 - Pyrgos Zentrum",1], // 39 - Pyrgos_Zentrum
-	   [[17769.818,41.113083,10566.192], "40 - Ekali Stones",1], // 40 - Ekali Stones 
-	   [[19406.996,50.685932,7955.5903], "41 - Lonely",1], // 42 - Lonely
+	   [[17769.818,41.113083,10566.192], "40 - Ekali Stones",0], // 40 - Ekali Stones 
+	   [[19406.996,50.685932,7955.5903], "41 - Lonely",0], // 42 - Lonely
 
-	   [[18943.773,28.606129,16660.947], "42 - Rodopoli Graveyard",1], // 42 - Rodopoli Graveyard
-	   [[18420.234,49.431179,15511.571], "43 - Charkia Storage",1], // 43 - Charkia Storage
-	   [[18147.764,25.077732,15225.152], "44 - Charkia",1], // 44 - Charkia
+	   [[18943.773,28.606129,16660.947], "42 - Rodopoli Graveyard",0], // 42 - Rodopoli Graveyard
+	   [[18420.234,49.431179,15511.571], "43 - Charkia Storage",0], // 43 - Charkia Storage
+	   [[18147.764,25.077732,15225.152], "44 - Charkia",0], // 44 - Charkia
 
 	   [[19702.965,89.270676,12960.619], "45 - Dorida Woods",1], // 45 - Dorida Woods
-	   [[20155.959,41.908695,11718.664], "46 - Chalikea",1], // 46 - Chalikea
-	   [[20555.693,39.293385,9022.5293], "47 - Panagia",1], // 47 - Panagia
+	   [[20155.959,41.908695,11718.664], "46 - Chalikea",0], // 46 - Chalikea
+	   [[20555.693,39.293385,9022.5293], "47 - Panagia",0], // 47 - Panagia
 	   
-	   [[20907.025,34.035168,6664.6289], "48 - Selakano",1], // 48 - Selakano
-	   [[20092.324,17.621887,20026.533], "49 - Pefka Colloseum",1], // 49 - Pefka Colloseum
-	   [[20958.469,15.521555,19261.99], "50 - Pefkas Lab",1], // 50 - Pefkas Lab
+	   [[20907.025,34.035168,6664.6289], "48 - Selakano",0], // 48 - Selakano
+	   [[20092.324,17.621887,20026.533], "49 - Pefka Colloseum",0], // 49 - Pefka Colloseum
+	   [[20958.469,15.521555,19261.99], "50 - Pefkas Lab",0], // 50 - Pefkas Lab
 	   
 	   [[50940,0,17008], "51 - Paros",1], // 51 - Paros
 	   [[21373.045,18.855602,16254.126], "52 - Kalochori",1], // 52 - Kalochori
 	   [[21185.318,2.11974,14617.707], "53 - Limni Swamp",1], // 53 - Limni Swamp
 	   
-	   [[22010.072,29.125452,21064.441], "54 - Pefkas Palace",1], // 54 - Pefkas Palace
-	   [[22283.615,14.165822,18499.398], "55 - Almyra West",1], // 55 - Almyra West
+	   [[22010.072,29.125452,21064.441], "54 - Pefkas Palace",0], // 54 - Pefkas Palace
+	   [[22283.615,14.165822,18499.398], "55 - Almyra West",0], // 55 - Almyra West
 	   [[22599.842,13.634861,16825.371], "56 - Almyra South",1], // 56 - Almyra South
 	   
-	   [[23371.816,3.9426758,24183.539], "57 - Sideras",1], // 57 - Sideras
-	   [[23466.807,90.535362,21137.943], "58 - Delfinaki Military",1], // 58 - Delfinaki Military
-	   [[24755.986,3.8023796,19153.188], "59 - Almyra North",1], // 59 - Almyra North
+	   [[23371.816,3.9426758,24183.539], "57 - Sideras",0], // 57 - Sideras
+	   [[23466.807,90.535362,21137.943], "58 - Delfinaki Military",0], // 58 - Delfinaki Military
+	   [[24755.986,3.8023796,19153.188], "59 - Almyra North",0], // 59 - Almyra North
 	   
-	   [[26731.115,20.005753,24638.008], "60 - Molos Airbase",1], // 60 - Molos Airbase
-	   [[26989.885,20.367672,23206.453], "61 - Molos Town",1], // 61 - Molos Town
-	   [[25420.861,10.028322,20338.611], "62 - Refinery",1] // 62 - Refinery
+	   [[26731.115,20.005753,24638.008], "60 - Molos Airbase",0], // 60 - Molos Airbase
+	   [[26989.885,20.367672,23206.453], "61 - Molos Town",0], // 61 - Molos Town
+	   [[25420.861,10.028322,20338.611], "62 - Refinery",0] // 62 - Refinery
 ];
 
 //East
@@ -147,88 +147,88 @@ GVAR(locations_east) =
     [[7147,0,10947], "Marine Basis", 0],
     [[13769,0,6378], "FOB", 0],
 	
-        [[4925.6323,341.19653,21895.656], "1 - Throns castel",1], // 1 - Throns_castel
-	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",1], // 2 - Oreokastro
-	   [[4910.3472,197.1022,19458.254], "3 - Waffenlager Nord West",1], // 3 - Waffenlager_Nord_West
-	   [[3360.3782,67.56945,18310.93], "4 - Villa Constans",1], // 4 - Villa_Constans
+        [[4925.6323,341.19653,21895.656], "1 - Throns castel",0], // 1 - Throns_castel
+	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",0], // 2 - Oreokastro
+	   [[4910.3472,197.1022,19458.254], "3 - Waffenlager Nord West",0], // 3 - Waffenlager_Nord_West
+	   [[3360.3782,67.56945,18310.93], "4 - Villa Constans",0], // 4 - Villa_Constans
 
-	   [[5410.8721,76.737549,17909.359], "5 - Mine Gore",1], // 5 - Mine_Gore
-	   [[6181.8838,43.000999,16256.253], "6 - Kore Fabrik",1], // 6 - Kore_Fabrik
-	   [[4267.708,28.040495,13902.733], "7 - Checkpoint charlie",1], // 7 - Checkpoint_charlie
-	   [[3723.6956,18.555311,12999.2], "8 - Kavala Hospital",1], // 8 - Kavala_Hospital
+	   [[5410.8721,76.737549,17909.359], "5 - Mine Gore",0], // 5 - Mine_Gore
+	   [[6181.8838,43.000999,16256.253], "6 - Kore Fabrik",0], // 6 - Kore_Fabrik
+	   [[4267.708,28.040495,13902.733], "7 - Checkpoint charlie",0], // 7 - Checkpoint_charlie
+	   [[3723.6956,18.555311,12999.2], "8 - Kavala Hospital",0], // 8 - Kavala_Hospital
 
-	   [[5940.9346,101.7437,12461.137], "9 - Lager Panagiotis",1], // 9 - Lager_Panagiotis
-	   [[7233.4165,4.3041649,11030.594], "10 - Edessa",1], // 10 - Edessa
-	   [[9684.7617,3.5207906,22269.395], "11 - Krya Nera",1], // 11 - Krya_Nera
-	   [[8532.0986,68.093964,20879.943], "12 - Abdera Farm",1], // 12 - Abdera_Farm
+	   [[5940.9346,101.7437,12461.137], "9 - Lager Panagiotis",0], // 9 - Lager_Panagiotis
+	   [[7233.4165,4.3041649,11030.594], "10 - Edessa",0], // 10 - Edessa
+	   [[9684.7617,3.5207906,22269.395], "11 - Krya Nera",0], // 11 - Krya_Nera
+	   [[8532.0986,68.093964,20879.943], "12 - Abdera Farm",0], // 12 - Abdera_Farm
 	   
-	   [[9410.1563,118.25887,20300.502], "13 - Abdera Rathaus",1], // 13 - Abdera_Rathaus
-	   [[10405.196,120.67762,19023.145], "14 - Galati alte Post",1], // 14 - Galati_alte_Post
-	   [[7533.3193,134.73981,18346.297], "15 - Enclave Syrta",1], // 15 - Enclave_Syrta
+	   [[9410.1563,118.25887,20300.502], "13 - Abdera Rathaus",0], // 13 - Abdera_Rathaus
+	   [[10405.196,120.67762,19023.145], "14 - Galati alte Post",0], // 14 - Galati_alte_Post
+	   [[7533.3193,134.73981,18346.297], "15 - Enclave Syrta",0], // 15 - Enclave_Syrta
 
-	   [[7111.4897,111.96675,16438.803], "16 - Kore Zentrum",1], // 16 - Kore_Zentrum
-	   [[9196.6797,120.77501,15821.593], "17 - Checkpoint Agios Dionisos",1], // 17 - Checkpoint Agios Dionisos
-	   [[9301.5342,30.298265,13664.528], "18 - Xirolimni Damm",1], // 18 - Xirolimni_Damm",1
+	   [[7111.4897,111.96675,16438.803], "16 - Kore Zentrum",0], // 16 - Kore_Zentrum
+	   [[9196.6797,120.77501,15821.593], "17 - Checkpoint Agios Dionisos",0], // 17 - Checkpoint Agios Dionisos
+	   [[9301.5342,30.298265,13664.528], "18 - Xirolimni Damm",0], // 18 - Xirolimni_Damm",1
 	   
-	   [[9468.4805,26.262537,8236.5488], "19 - Hühnerfarm Sfaka",1], // 19 - Hühnerfarm_Sfaka
+	   [[9468.4805,26.262537,8236.5488], "19 - Hühnerfarm Sfaka",0], // 19 - Hühnerfarm_Sfaka
 
-	   [[12318.005,20.195953,22856.318], "20 - Tonos Bucht",1], // 20 - Tonos_Bucht
-	   [[13013.089,32.230129,19448.695], "21 - Checkpoint Ifestonia",1], // Checkpoint_Ifestonia
-	   [[12672.666,34.210361,16390.48], "22 - Lacca Fabrik",1], // 22 - Lacca_Fabrik
+	   [[12318.005,20.195953,22856.318], "20 - Tonos Bucht",0], // 20 - Tonos_Bucht
+	   [[13013.089,32.230129,19448.695], "21 - Checkpoint Ifestonia",0], // Checkpoint_Ifestonia
+	   [[12672.666,34.210361,16390.48], "22 - Lacca Fabrik",0], // 22 - Lacca_Fabrik
 
-	   [[13248.13,13.200888,14947.823], "23 - Stavros Radar",1], // 23 - Stavros_Radar
-	   [[12151.891,9.668313,14330.698], "24 - Neochori Wollmarkt",1], // 24 - Neochori_Wollmarkt
-	   [[11105.64,19.684849,13325.393], "25 - Poliakko alte Brennerei",1], // 25 - Poliakko_alte_Brennerei
+	   [[13248.13,13.200888,14947.823], "23 - Stavros Radar",0], // 23 - Stavros_Radar
+	   [[12151.891,9.668313,14330.698], "24 - Neochori Wollmarkt",0], // 24 - Neochori_Wollmarkt
+	   [[11105.64,19.684849,13325.393], "25 - Poliakko alte Brennerei",0], // 25 - Poliakko_alte_Brennerei
 	   
-	   [[10675.173,16.757935,12266.578], "26 - Therisa Markt",1], // 26 - Therisa_Markt
-	   [[10819.854,6.4413772,10859.053], "27 - Drimea Fährstation",1], // 27 - Drimea_Fährstation
-	   [[11562.51,77.303802,7045.9185], "28 - Egino Farmhaus",1], // 28 - Egino_Farmhaus
+	   [[10675.173,16.757935,12266.578], "26 - Therisa Markt",0], // 26 - Therisa_Markt
+	   [[10819.854,6.4413772,10859.053], "27 - Drimea Fährstation",0], // 27 - Drimea_Fährstation
+	   [[11562.51,77.303802,7045.9185], "28 - Egino Farmhaus",0], // 28 - Egino_Farmhaus
   
-	   [[14266.871,43.789253,22215.367], "29 - Hanf Plantage Frini",1], // 29 - Hanf_Plantage_Frini 
-	   [[14716.515,46.701706,20735.465], "30 - Frini Polizeistation",1], // 30 - Frini_Polizeistation
-	   [[14320.399,36.900391,18909.221], "31 - Athira Factory",1], // 31 - Athira_Factory
+	   [[14266.871,43.789253,22215.367], "29 - Hanf Plantage Frini",0], // 29 - Hanf_Plantage_Frini 
+	   [[14716.515,46.701706,20735.465], "30 - Frini Polizeistation",0], // 30 - Frini_Polizeistation
+	   [[14320.399,36.900391,18909.221], "31 - Athira Factory",0], // 31 - Athira_Factory
 	   
-	   [[14937.858,17.528454,17153.338], "32 - Airbase Altis",1], // 32 - Airbase_Altis
-	   [[13589.743,16.363777,12166.921], "33 - xxxxxxxxxxxxx",1], // 33 - xxxxxxxxxxxxx
-	   [[11908.478,15.18861,9707.3877], "34 - Alpaka Residenz",1], // 34 - Alpaka_Residenz
+	   [[14937.858,17.528454,17153.338], "32 - Airbase Altis",0], // 32 - Airbase_Altis
+	   [[13589.743,16.363777,12166.921], "33 - xxxxxxxxxxxxx",0], // 33 - xxxxxxxxxxxxx
+	   [[11908.478,15.18861,9707.3877], "34 - Alpaka Residenz",0], // 34 - Alpaka_Residenz
 	   
-	   [[16587.895,35.317459,19002.33], "35 - Kalithea Kontrolltower",1], // 35 - Kalithea_Kontrolltower
+	   [[16587.895,35.317459,19002.33], "35 - Kalithea Kontrolltower",0], // 35 - Kalithea_Kontrolltower
 	   
 	   [[16451.031,24.131969,17237.797], "36 - Thelos Zentrum",1], // 36 - Thelos_Zentrum
 	   [[16681.539,18.231377,16143.08], "37 - Athira Kirchplatz",1], // 37 - Athira_Kirchplatz
 	   [[16703.346,10.311413,13522.601], "38 - xxxxxxxxxxx",1], // 38 _ xxxxxxxxxxxxxx
 
-	   [[16611.455,13.550769,12640.338], "39 - Pyrgos Zentrum",1], // 39 - Pyrgos_Zentrum
-	   [[17769.818,41.113083,10566.192], "40 - Ekali Stones",1], // 40 - Ekali Stones 
-	   [[19406.996,50.685932,7955.5903], "41 - Lonely",1], // 42 - Lonely
+	   [[16611.455,13.550769,12640.338], "39 - Pyrgos Zentrum",0], // 39 - Pyrgos_Zentrum
+	   [[17769.818,41.113083,10566.192], "40 - Ekali Stones",0], // 40 - Ekali Stones 
+	   [[19406.996,50.685932,7955.5903], "41 - Lonely",0], // 42 - Lonely
 
 	   [[18943.773,28.606129,16660.947], "42 - Rodopoli Graveyard",1], // 42 - Rodopoli Graveyard
 	   [[18420.234,49.431179,15511.571], "43 - Charkia Storage",1], // 43 - Charkia Storage
 	   [[18147.764,25.077732,15225.152], "44 - Charkia",1], // 44 - Charkia
 
-	   [[19702.965,89.270676,12960.619], "45 - Dorida Woods",1], // 45 - Dorida Woods
-	   [[20155.959,41.908695,11718.664], "46 - Chalikea",1], // 46 - Chalikea
-	   [[20555.693,39.293385,9022.5293], "47 - Panagia",1], // 47 - Panagia
+	   [[19702.965,89.270676,12960.619], "45 - Dorida Woods",0], // 45 - Dorida Woods
+	   [[20155.959,41.908695,11718.664], "46 - Chalikea",0], // 46 - Chalikea
+	   [[20555.693,39.293385,9022.5293], "47 - Panagia",0], // 47 - Panagia
 	   
-	   [[20907.025,34.035168,6664.6289], "48 - Selakano",1], // 48 - Selakano
-	   [[20092.324,17.621887,20026.533], "49 - Pefka Colloseum",1], // 49 - Pefka Colloseum
-	   [[20958.469,15.521555,19261.99], "50 - Pefkas Lab",1], // 50 - Pefkas Lab
+	   [[20907.025,34.035168,6664.6289], "48 - Selakano",0], // 48 - Selakano
+	   [[20092.324,17.621887,20026.533], "49 - Pefka Colloseum",0], // 49 - Pefka Colloseum
+	   [[20958.469,15.521555,19261.99], "50 - Pefkas Lab",0], // 50 - Pefkas Lab
 	   
-	   [[50940,0,17008], "51 - Paros",1], // 51 - Paros
-	   [[21373.045,18.855602,16254.126], "52 - Kalochori",1], // 52 - Kalochori
-	   [[21185.318,2.11974,14617.707], "53 - Limni Swamp",1], // 53 - Limni Swamp
+	   [[50940,0,17008], "51 - Paros",0], // 51 - Paros
+	   [[21373.045,18.855602,16254.126], "52 - Kalochori",0], // 52 - Kalochori
+	   [[21185.318,2.11974,14617.707], "53 - Limni Swamp",0], // 53 - Limni Swamp
 	   
-	   [[22010.072,29.125452,21064.441], "54 - Pefkas Palace",1], // 54 - Pefkas Palace
-	   [[22283.615,14.165822,18499.398], "55 - Almyra West",1], // 55 - Almyra West
-	   [[22599.842,13.634861,16825.371], "56 - Almyra South",1], // 56 - Almyra South
+	   [[22010.072,29.125452,21064.441], "54 - Pefkas Palace",0], // 54 - Pefkas Palace
+	   [[22283.615,14.165822,18499.398], "55 - Almyra West",0], // 55 - Almyra West
+	   [[22599.842,13.634861,16825.371], "56 - Almyra South",0], // 56 - Almyra South
 	   
-	   [[23371.816,3.9426758,24183.539], "57 - Sideras",1], // 57 - Sideras
-	   [[23466.807,90.535362,21137.943], "58 - Delfinaki Military",1], // 58 - Delfinaki Military
-	   [[24755.986,3.8023796,19153.188], "59 - Almyra North",1], // 59 - Almyra North
+	   [[23371.816,3.9426758,24183.539], "57 - Sideras",0], // 57 - Sideras
+	   [[23466.807,90.535362,21137.943], "58 - Delfinaki Military",0], // 58 - Delfinaki Military
+	   [[24755.986,3.8023796,19153.188], "59 - Almyra North",0], // 59 - Almyra North
 	   
-	   [[26731.115,20.005753,24638.008], "60 - Molos Airbase",1], // 60 - Molos Airbase
-	   [[26989.885,20.367672,23206.453], "61 - Molos Town",1], // 61 - Molos Town
-	   [[25420.861,10.028322,20338.611], "62 - Refinery",1] // 62 - Refinery
+	   [[26731.115,20.005753,24638.008], "60 - Molos Airbase",0], // 60 - Molos Airbase
+	   [[26989.885,20.367672,23206.453], "61 - Molos Town",0], // 61 - Molos Town
+	   [[25420.861,10.028322,20338.611], "62 - Refinery",0] // 62 - Refinery
 
 ];
 

--- a/OPT_mission.Altis/common/functions/fnc_weaponcheck.sqf
+++ b/OPT_mission.Altis/common/functions/fnc_weaponcheck.sqf
@@ -30,10 +30,30 @@ if !(_typeOfPlayer in (GVARMAIN(officer) + GVARMAIN(pilots) + GVARMAIN(crew))) t
     } forEach (weapons _unit);
 };
 
-// check launcher
-if !(_typeOfPlayer in GVARMAIN(rocketmen)) then {
+// check Light launcher
+if !(_typeOfPlayer in GVARMAIN(Lightrocketmen)) then {
     {
-        if (_x in GVARMAIN(launchers)) then {
+        if (_x in GVARMAIN(lightlaunchers)) then {
+            _unit removeWeapon _x;
+            _bad_item_used = true;
+        };
+    } forEach (weapons _unit);
+};
+
+// check Heavy launcher
+if !(_typeOfPlayer in GVARMAIN(Heavyrocketmen)) then {
+    {
+        if (_x in GVARMAIN(Heavylaunchers)) then {
+            _unit removeWeapon _x;
+            _bad_item_used = true;
+        };
+    } forEach (weapons _unit);
+};
+
+// check AA launcher
+if !(_typeOfPlayer in GVARMAIN(AArocketmen)) then {
+    {
+        if (_x in GVARMAIN(AAlaunchers)) then {
             _unit removeWeapon _x;
             _bad_item_used = true;
         };

--- a/OPT_mission.Altis/main/functions/fnc_setup_classnames.sqf
+++ b/OPT_mission.Altis/main/functions/fnc_setup_classnames.sqf
@@ -132,35 +132,55 @@ GVARMAIN(SMG) = [
 	"OPT_SMG_02_F"
 ];
 
-/* AT-Schützen UND LAUNCHER */
-GVARMAIN(rocketmen) = [
-	"OPT_NATO_Luftabwehrspezialist",
-	"OPT_CSAT_Luftabwehrspezialist",
+/* Light AT-Schützen UND LAUNCHER */
+GVARMAIN(Lightrocketmen) = [
 	"OPT_NATO_PA_Schuetze",
 	"OPT_NATO_PA_Schuetze_T",
 	"OPT_CSAT_PA_Schuetze_T",
 	"OPT_CSAT_PA_Schuetze",
-	"OPT_NATO_PA_Schuetze_Heavy",
-	"OPT_CSAT_PA_Schuetze_Heavy",
 	"OPT_NATO_Aufklaerung_Spaeher_AT",
 	"OPT_CSAT_Aufklaerung_Spaeher_AT",
 	"OPT_NATO_Aufklaerung_Spaeher_AT_T",
 	"OPT_CSAT_Aufklaerung_Spaeher_AT_T"
 ];
 
-GVARMAIN(launchers) = [
+GVARMAIN(lightlaunchers) = [
     "OPT_launch_B_RPG32_F",
     "OPT_launch_RPG32_F",
     "OPT_launch_NLAW_F",
     "OPT_launch_NLAW_M_F",
+	"OPT_launch_MRAWS_green_rail_F",
+	"OPT_launch_MRAWS_olive_rail_F",
+	"launch_RPG7_F"
+];
+
+/* Heavy AT-Schützen UND LAUNCHER */
+GVARMAIN(Heavyrocketmen) = [
+	"OPT_NATO_PA_Schuetze_Heavy",
+	"OPT_CSAT_PA_Schuetze_Heavy"
+];
+
+GVARMAIN(Heavylaunchers) = [
+    "OPT_launch_O_Titan_short_F",
+    "OPT_launch_B_Titan_short_F",
+	"OPT_launch_O_Titan_short_ghex_F",
+	"OPT_launch_B_Titan_short_tna_F",
+	"OPT_launch_O_Vorona_green_F"
+];
+
+/* AA-Schützen UND LAUNCHER */
+GVARMAIN(AArocketmen) = [
+	"OPT_NATO_Luftabwehrspezialist",
+	"OPT_CSAT_Luftabwehrspezialist"
+];
+
+GVARMAIN(AAlaunchers) = [
     "OPT_launch_B_Titan_F",
 	"OPT_launch_B_Titan_tna_F",
     "OPT_launch_O_Titan_F",
-    "OPT_launch_O_Titan_short_F",
-    "OPT_launch_B_Titan_short_F",
-	"Weapon_launch_MRAWS_green_rail_F",
-	"Weapon_launch_MRAWS_olive_rail_F"
+	"OPT_launch_O_Titan_ghex_F"
 ];
+
 
 /* OPERATOR */
 GVARMAIN(operator) = [

--- a/OPT_mission.Altis/mission.sqm
+++ b/OPT_mission.Altis/mission.sqm
@@ -1,64 +1,52 @@
 version=53;
 class EditorData
 {
-	moveGridStep=1;
+	moveGridStep=0.25;
 	angleGridStep=0.2617994;
 	scaleGridStep=100;
 	autoGroupingDist=10;
-	toggles=577;
+	toggles=586;
 	class ItemIDProvider
 	{
-		nextID=6439;
+		nextID=8184;
 	};
 	class MarkerIDProvider
 	{
-		nextID=36;
+		nextID=39;
 	};
 	class LayerIndexProvider
 	{
-		nextID=26231;
+		nextID=26661;
 	};
 	class Camera
 	{
-		pos[]={68.71833,28.993156,16945.631};
-		dir[]={0.15132596,-0.34468737,-0.92644542};
-		up[]={0.055569179,0.93870813,-0.34020564};
-		aside[]={-0.98692334,-2.195884e-008,-0.16120392};
+		pos[]={14072.249,171.94337,12376.186};
+		dir[]={0.45334205,-0.88009298,0.1411753};
+		up[]={0.84029001,0.47479755,0.261675};
+		aside[]={0.29732817,-2.0605512e-007,-0.95477897};
 	};
 };
 binarizationWanted=0;
 addons[]=
 {
-	"A3_Structures_F_Mil_Helipads",
-	"A3_Structures_F_Civ_InfoBoards",
-	"A3_Structures_F_Bootcamp_Civ_SportsGrounds",
-	"A3_Ui_F",
-	"ace_map",
-	"A3_Supplies_F_Exp_Ammoboxes",
-	"ace_dragging",
-	"A3_Structures_F_Mil_Flags",
-	"A3_Structures_F_Civ_Camping",
-	"A3_Structures_F_Items_Electronics",
-	"opt_characters",
-	"A3_Weapons_F",
-	"tfar_handhelds",
 	"A3_Characters_F",
-	"opt_weapons",
-	"A3_Structures_F_Exp_Naval_Piers",
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F_Curator_Curator",
+	"A3_Structures_F_Mil_Helipads",
 	"A3_Signs_F_Signs_Ad",
+	"opt_weapons",
+	"opt_characters",
 	"A3_Weapons_F_Acc",
 	"ace_flashsuppressors",
+	"A3_Weapons_F",
 	"A3_Weapons_F_Exp",
+	"tfar_handhelds",
 	"A3_Weapons_F_Items",
 	"ace_laserpointer",
 	"A3_Characters_F_Heads",
 	"A3_Weapons_F_Mark_Acc",
 	"A3_Weapons_F_Orange",
 	"ace_trenches",
-	"A3_Weapons_F_Tank_Launchers_MRAWS",
-	"A3_Weapons_F_Tank",
 	"A3_Characters_F_Exp",
 	"ace_reload",
 	"A3_Weapons_F_LongRangeRifles_M320",
@@ -81,8 +69,45 @@ addons[]=
 	"A3_Structures_F_Tank_Military_Fortifications",
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Mil_BagBunker",
-	"A3_Ui_F_Orange",
 	"A3_Weapons_F_Explosives",
+	"A3_Ui_F",
+	"A3_Structures_F_Civ_Accessories",
+	"A3_Structures_F_Households_House_Small03",
+	"A3_Rocks_F_Water",
+	"A3_Structures_F_Households_House_Small01",
+	"A3_Structures_F_Households_House_Big01",
+	"A3_Structures_F_Households_House_Small02",
+	"A3_Structures_F_Households_Addons",
+	"A3_Structures_F_Ind_ConcreteMixingPlant",
+	"A3_Structures_F_Ind_Factory",
+	"A3_Structures_F_Ind_Shed",
+	"A3_Structures_F_Ind_DieselPowerPlant",
+	"A3_Structures_F_Ind_Tank",
+	"A3_Structures_F_EPA_Civ_Constructions",
+	"A3_Structures_F_Civ_Camping",
+	"A3_Structures_F_Items_Vessels",
+	"A3_Structures_F_Ind_Cargo",
+	"ace_cargo",
+	"A3_Structures_F_Mil_Cargo",
+	"A3_Structures_F_Civ_Constructions",
+	"A3_Structures_F_EPA_Mil_Scrapyard",
+	"A3_Structures_F_EPB_Items_Vessels",
+	"A3_Modules_F",
+	"A3_Structures_F_Mil_Radar",
+	"A3_Structures_F_Ind_Windmill",
+	"A3_Structures_F_Civ_Garbage",
+	"ace_dragging",
+	"A3_Structures_F_Civ_Market",
+	"A3_Structures_F_EPA_Civ_Camping",
+	"cba_xeh",
+	"A3_Signs_F",
+	"A3_Structures_F_Items_Tools",
+	"A3_Structures_F_EPA_Items_Tools",
+	"A3_Structures_F_EPA_Items_Food",
+	"A3_Structures_F_EPA_Items_Vessels",
+	"A3_Structures_F_EPB_Civ_Camping",
+	"ace_interaction",
+	"A3_Props_F_Exp_Industrial_HeavyEquipment",
 	"A3_Structures_F_Kart_Civ_SportsGrounds",
 	"A3_Static_F_Jets_SAM_System_02",
 	"A3_Static_F_Destroyer_Ship_MRLS_01",
@@ -90,12 +115,19 @@ addons[]=
 	"A3_Static_F_Jets_SAM_System_01",
 	"A3_Static_F_Jets_AAA_System_01",
 	"A3_Misc_F_Helpers",
+	"A3_Structures_F_Civ_InfoBoards",
+	"A3_Structures_F_Items_Electronics",
 	"A3_Structures_F_Heli_Items_Electronics",
 	"A3_Props_F_Exp_Military_Camps",
 	"A3_Props_F_Exp_A_Military_Equipment",
 	"A3_Boat_F_Jets_Carrier_01",
 	"A3_Boat_F_Destroyer_Destroyer_01",
+	"A3_Structures_F_Bootcamp_Civ_SportsGrounds",
+	"ace_map",
+	"A3_Supplies_F_Exp_Ammoboxes",
+	"A3_Structures_F_Mil_Flags",
 	"A3_Structures_F_Exp_Infrastructure_Pavements",
+	"A3_Structures_F_Exp_Naval_Piers",
 	"A3_Data_F_Exp_A_Virtual",
 	"A3_Weapons_F_Mark_LongRangeRifles_DMR_03",
 	"A3_Weapons_F_Pistols_Rook40"
@@ -104,65 +136,63 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=48;
+		items=54;
 		class Item0
+		{
+			className="A3_Characters_F";
+			name="Arma 3 Alpha - Characters and Clothing";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item1
+		{
+			className="A3_Weapons_F";
+			name="Arma 3 Alpha - Weapons and Accessories";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item2
+		{
+			className="A3_Modules_F_Curator";
+			name="Arma 3 Zeus Update - Scripted Modules";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item3
 		{
 			className="A3_Structures_F_Mil";
 			name="Arma 3 - Military Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item1
-		{
-			className="A3_Structures_F";
-			name="Arma 3 - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item2
-		{
-			className="A3_Structures_F_Bootcamp";
-			name="Arma 3 Bootcamp Update - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item3
-		{
-			className="A3_Ui_F";
-			name="Arma 3 - User Interface";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
 		class Item4
 		{
-			className="ace_map";
-			name="ACE3 - Map";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
+			className="A3_Signs_F";
+			name="Arma 3 - Signs";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
 		};
 		class Item5
 		{
-			className="A3_Supplies_F_Exp";
-			name="Arma 3 Apex - Ammoboxes and Supplies";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
+			className="opt_weapons";
+			name="opt_weapons";
 		};
 		class Item6
-		{
-			className="ace_dragging";
-			name="ACE3 - Dragging";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item7
 		{
 			className="opt_characters";
 			name="opt_characters";
 		};
+		class Item7
+		{
+			className="ace_flashsuppressors";
+			name="ACE3 - Flash Suppressors";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
 		class Item8
 		{
-			className="A3_Weapons_F";
-			name="Arma 3 Alpha - Weapons and Accessories";
+			className="A3_Weapons_F_Exp";
+			name="Arma 3 Apex - Weapons and Accessories";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
@@ -174,262 +204,306 @@ class AddonsMetaData
 		};
 		class Item10
 		{
-			className="A3_Characters_F";
-			name="Arma 3 Alpha - Characters and Clothing";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item11
-		{
-			className="opt_weapons";
-			name="opt_weapons";
-		};
-		class Item12
-		{
-			className="A3_Structures_F_Exp";
-			name="Arma 3 Apex - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item13
-		{
-			className="A3_Modules_F_Curator";
-			name="Arma 3 Zeus Update - Scripted Modules";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item14
-		{
-			className="A3_Signs_F";
-			name="Arma 3 - Signs";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item15
-		{
-			className="ace_flashsuppressors";
-			name="ACE3 - Flash Suppressors";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item16
-		{
-			className="A3_Weapons_F_Exp";
-			name="Arma 3 Apex - Weapons and Accessories";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item17
-		{
 			className="ace_laserpointer";
 			name="ACE3 - Laser Pointer";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item18
+		class Item11
 		{
 			className="A3_Weapons_F_Mark";
 			name="Arma 3 Marksmen - Weapons and Accessories";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item19
+		class Item12
 		{
 			className="A3_Weapons_F_Orange";
 			name="Arma 3 Orange - Weapons and Accessories";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item20
+		class Item13
 		{
 			className="ace_trenches";
 			name="ACE3 - Trenches";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item21
-		{
-			className="A3_Weapons_F_Tank";
-			name="Arma 3 Tank - Weapons and Accessories";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item22
+		class Item14
 		{
 			className="A3_Characters_F_Exp";
 			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item23
+		class Item15
 		{
 			className="ace_reload";
 			name="ACE3 - Reload";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item24
+		class Item16
 		{
 			className="ace_tripod";
 			name="ACE3 - Tripod";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item25
+		class Item17
 		{
 			className="ace_spottingscope";
 			name="ACE3 - Spotting Scope";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item26
+		class Item18
 		{
 			className="A3_Characters_F_Enoch";
 			name="Arma 3 Enoch - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item27
+		class Item19
 		{
 			className="ace_huntir";
 			name="ACE3 - HuntIR";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item28
+		class Item20
 		{
 			className="A3_Drones_F";
 			name="Arma 3 Beta - Drones";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item29
+		class Item21
 		{
 			className="A3_Characters_F_Orange";
 			name="Arma 3 Orange - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item30
+		class Item22
 		{
 			className="A3_Characters_F_Tacops";
 			name="Arma 3 Tac-Ops - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item31
+		class Item23
 		{
 			className="A3_Structures_F_Wrecks";
 			name="Arma 3 - Vehicle Wrecks";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item32
+		class Item24
 		{
 			className="A3_Props_F_Tank";
 			name="Arma 3 Tank - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item33
+		class Item25
 		{
 			className="ace_logistics_wirecutter";
 			name="ACE3 - Logistics Wire Cutter";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item34
+		class Item26
 		{
 			className="ace_concertina_wire";
 			name="ACE3 - Concertina Wire";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item35
+		class Item27
 		{
 			className="A3_Structures_F_Tank";
 			name="Arma 3 Tank - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
+		class Item28
+		{
+			className="A3_Structures_F";
+			name="Arma 3 - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item29
+		{
+			className="A3_Ui_F";
+			name="Arma 3 - User Interface";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item30
+		{
+			className="A3_Structures_F_Households";
+			name="Arma 3 - Houses";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item31
+		{
+			className="A3_Rocks_F";
+			name="Arma 3 - Rocks and Stones";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item32
+		{
+			className="A3_Structures_F_Ind";
+			name="Arma 3 - Industrial Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item33
+		{
+			className="A3_Structures_F_EPA";
+			name="Arma 3 Survive Episode - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item34
+		{
+			className="ace_cargo";
+			name="ACE3 - Cargo";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item35
+		{
+			className="A3_Structures_F_EPB";
+			name="Arma 3 Adapt Episode - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
 		class Item36
 		{
-			className="A3_Ui_F_Orange";
-			name="Arma 3 Orange - User Interface";
+			className="A3_Modules_F";
+			name="Arma 3 Alpha - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item37
 		{
-			className="A3_Structures_F_Kart";
-			name="Arma 3 Karts - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
+			className="ace_dragging";
+			name="ACE3 - Dragging";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
 		};
 		class Item38
 		{
-			className="A3_Static_F_Jets";
-			name="Arma 3 Jets - Turrets";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
+			className="ace_interaction";
+			name="ACE3 - Interaction";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
 		};
 		class Item39
-		{
-			className="A3_Static_F_Destroyer";
-			name="CFGPATCHES_A3_Static_F_Destroyer";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item40
-		{
-			className="A3_Misc_F";
-			name="Arma 3 - 3D Aids and Helpers";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item41
-		{
-			className="A3_Structures_F_Heli";
-			name="Arma 3 Helicopters - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item42
 		{
 			className="A3_Props_F_Exp";
 			name="Arma 3 Apex - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
+		class Item40
+		{
+			className="A3_Structures_F_Kart";
+			name="Arma 3 Karts - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item41
+		{
+			className="A3_Static_F_Jets";
+			name="Arma 3 Jets - Turrets";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item42
+		{
+			className="A3_Static_F_Destroyer";
+			name="CFGPATCHES_A3_Static_F_Destroyer";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
 		class Item43
+		{
+			className="A3_Misc_F";
+			name="Arma 3 - 3D Aids and Helpers";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item44
+		{
+			className="A3_Structures_F_Heli";
+			name="Arma 3 Helicopters - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item45
 		{
 			className="A3_Props_F_Exp_A";
 			name="Arma 3 Nexus Update - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item44
+		class Item46
 		{
 			className="A3_Boat_F_Jets";
 			name="Arma 3 Jets - Boats and Submersibles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item45
+		class Item47
 		{
 			className="A3_Boat_F_Destroyer";
 			name="Arma 3 Jets - Boats and Submersibles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item46
+		class Item48
+		{
+			className="A3_Structures_F_Bootcamp";
+			name="Arma 3 Bootcamp Update - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item49
+		{
+			className="ace_map";
+			name="ACE3 - Map";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item50
+		{
+			className="A3_Supplies_F_Exp";
+			name="Arma 3 Apex - Ammoboxes and Supplies";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item51
 		{
 			className="A3_Structures_F_Exp_Infrastructure";
 			name="Arma 3 Apex - Infrastructure Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item47
+		class Item52
+		{
+			className="A3_Structures_F_Exp";
+			name="Arma 3 Apex - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item53
 		{
 			className="A3_Data_F_Exp_A";
 			name="Arma 3 Nexus Update - Main Configuration";
@@ -4000,7 +4074,7 @@ class CustomAttributes
 																"BOOL"
 															};
 														};
-														value=0;
+														value=1;
 													};
 												};
 												class Item1
@@ -4045,7 +4119,7 @@ class CustomAttributes
 																"BOOL"
 															};
 														};
-														value=0;
+														value=1;
 													};
 												};
 												class Item1
@@ -9040,7 +9114,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=9;
+														value=8;
 													};
 												};
 												class Item1
@@ -9054,7 +9128,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=2;
+														value=1;
 													};
 												};
 											};
@@ -9085,7 +9159,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=9;
+														value=8;
 													};
 												};
 												class Item1
@@ -9099,7 +9173,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=2;
+														value=1;
 													};
 												};
 											};
@@ -9130,7 +9204,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=9;
+														value=8;
 													};
 												};
 												class Item1
@@ -9144,7 +9218,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=2;
+														value=1;
 													};
 												};
 											};
@@ -9175,7 +9249,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=5000;
+														value=4000;
 													};
 												};
 												class Item1
@@ -9189,7 +9263,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=2;
+														value=1;
 													};
 												};
 											};
@@ -13720,7 +13794,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=9200;
+														value=10800;
 													};
 												};
 												class Item1
@@ -13765,7 +13839,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=93.324127;
+														value=900;
 													};
 												};
 												class Item1
@@ -13810,7 +13884,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=4.5;
+														value=0;
 													};
 												};
 												class Item1
@@ -13855,7 +13929,7 @@ class CustomAttributes
 																"SCALAR"
 															};
 														};
-														value=30;
+														value=0;
 													};
 												};
 												class Item1
@@ -14811,3764 +14885,22 @@ class Mission
 		windForced=1;
 		year=2019;
 		day=26;
-		hour=14;
+		hour=6;
+		minute=0;
 		startFogDecay=0.014;
 		forecastFogDecay=0.014;
 	};
 	class Entities
 	{
-		items=73;
+		items=10;
 		class Item0
 		{
 			dataType="Layer";
 			name="Missionsumbau";
 			class Entities
 			{
-				items=12;
+				items=11;
 				class Item0
-				{
-					dataType="Layer";
-					name="NATO _ FOB";
-					class Entities
-					{
-						items=3;
-						class Item0
-						{
-							dataType="Layer";
-							name="NATO Marine Basen";
-							class Entities
-							{
-								items=4;
-								class Item0
-								{
-									dataType="Layer";
-									name="NATO Marine Base N";
-									id=3564;
-									atlOffset=185.97;
-								};
-								class Item1
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={8344.7832,59.597172,25294.633};
-										angles[]={0,3.9462688,0};
-									};
-									side="Empty";
-									class Attributes
-									{
-										skill=0.60000002;
-									};
-									id=5252;
-									type="Land_HelipadCircle_F";
-									atlOffset=2.7912712;
-								};
-								class Item2
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={8357.3154,61.744057,25291.783};
-										angles[]={0,4.8950772,0};
-									};
-									side="Empty";
-									class Attributes
-									{
-										skill=0.60000002;
-										init="call{this setVariable [""opt_warehouse_data"", [""Marine-Ausrüstung"", ""sea"", west]]}";
-										disableSimulation=1;
-									};
-									id=5253;
-									type="Land_InfoStand_V1_F";
-									atlOffset=0.37273788;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="ObjectTextureCustom0";
-											expression="_this setObjectTextureGlobal [0,_value]";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="opt_core\bilder\nato_nachschub.paa";
-												};
-											};
-										};
-										class Attribute1
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=2;
-									};
-								};
-								class Item3
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={8357.375,61.533375,25291.67};
-										angles[]={0,2.546741,0};
-									};
-									side="Empty";
-									class Attributes
-									{
-										disableSimulation=1;
-										aiRadarUsage=28025824;
-									};
-									id=5254;
-									type="Land_TyreBarrier_01_F";
-									atlOffset=0.39227295;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-							};
-							id=3549;
-							atlOffset=-55.5588;
-						};
-						class Item1
-						{
-							dataType="Layer";
-							name="N_basismodul";
-							class Entities
-							{
-								items=9;
-								class Item0
-								{
-									dataType="Layer";
-									name="N_absperrungen";
-									class Entities
-									{
-										items=1;
-										class Item0
-										{
-											dataType="Marker";
-											position[]={22.081787,-2.4065857,16967.443};
-											name="respawn_west";
-											type="respawn_unknown";
-											colorName="ColorBlue";
-											angle=324.34888;
-											id=5255;
-											atlOffset=183.40105;
-										};
-									};
-									id=61;
-									atlOffset=183.40105;
-								};
-								class Item1
-								{
-									dataType="Layer";
-									name="N_sicherh_zonen";
-									class Entities
-									{
-										items=3;
-										class Item0
-										{
-											dataType="Marker";
-											position[]={18.232788,328.90948,16860.279};
-											name="Todeszone_NATO_2";
-											markerType="ELLIPSE";
-											type="Empty";
-											colorName="ColorWEST";
-											alpha=0;
-											fillName="SolidBorder";
-											a=3000;
-											b=3000;
-											angle=161.12625;
-											drawBorder=1;
-											id=5256;
-											atlOffset=305.5325;
-										};
-										class Item1
-										{
-											dataType="Trigger";
-											position[]={27.457031,-174.31189,16863.641};
-											angle=3.0209014;
-											class Attributes
-											{
-												text="CSAT Todeszone";
-												condition="call{vehicle player in thisList}";
-												onActivation="call{{player setDamage 1} foreach thisList; systemChat ""Ein CSAT Spieler wurde auf Grund des Betretens der feindlichen Basis automatisch getötet!""}";
-												sizeA=3000;
-												sizeB=3000;
-												timeout[]={10,10,10};
-												interuptable=1;
-												repeatable=1;
-												activationBy="EAST";
-											};
-											id=5257;
-											type="EmptyDetector";
-											atlOffset=11.261673;
-										};
-										class Item2
-										{
-											dataType="Trigger";
-											position[]={27.215698,24.387939,16863.678};
-											angle=3.3637528;
-											class Attributes
-											{
-												text="befriedeter Bereich";
-												condition="call{vehicle player in thisList}";
-												onActivation="call{systemChat ""Sie bewegen sich in Richtung der Feindbasis! Sofort abdrehen!""}";
-												sizeA=3500;
-												sizeB=3500;
-												interuptable=1;
-												repeatable=1;
-												activationBy="EAST";
-											};
-											id=5258;
-											type="EmptyDetector";
-											atlOffset=1.0111256;
-										};
-									};
-									id=152;
-									atlOffset=27.466516;
-								};
-								class Item2
-								{
-									dataType="Layer";
-									name="N_marker";
-									class Entities
-									{
-										items=2;
-										class Item0
-										{
-											dataType="Marker";
-											position[]={41.635864,330.67938,16894.654};
-											name="marker_nato_flagge_2";
-											type="flag_NATO";
-											angle=250.54964;
-											id=5259;
-											atlOffset=307.2981;
-										};
-										class Item1
-										{
-											dataType="Marker";
-											position[]={12.54895,15.254059,16967.346};
-											name="marker_113";
-											type="b_unknown";
-											angle=54.093243;
-											id=5260;
-											atlOffset=201.08359;
-										};
-									};
-									id=157;
-									atlOffset=149.59987;
-								};
-								class Item3
-								{
-									dataType="Layer";
-									name="N_auslöser";
-									class Entities
-									{
-										items=5;
-										class Item0
-										{
-											dataType="Trigger";
-											position[]={1.914,23.533951,16988.1};
-											angle=6.2608085;
-											class Attributes
-											{
-												name="nato_trigger_Waffenwechsel2";
-												text="Trigger für Waffenwechsel-Dialog";
-												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
-												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=5.915;
-												sizeB=6;
-												sizeC=3.2160001;
-												repeatable=1;
-												activationBy="WEST";
-												isRectangle=1;
-											};
-											id=5261;
-											type="EmptyDetectorAreaR50";
-											atlOffset=0.16709518;
-										};
-										class Item1
-										{
-											dataType="Trigger";
-											position[]={-57.361816,19.6763,16832.986};
-											angle=0.16305743;
-											class Attributes
-											{
-												name="opt_warehouse_garbage_collector_4";
-												text="Löschbereich für Wracks Landebahn";
-												sizeA=276.939;
-												sizeB=485.70401;
-												repeatable=1;
-												activationBy="ANY";
-												isRectangle=1;
-											};
-											id=5262;
-											type="EmptyDetectorAreaR50";
-											atlOffset=205.36232;
-										};
-										class Item2
-										{
-											dataType="Trigger";
-											position[]={33.023998,24.132187,16865.988};
-											angle=1.583746;
-											class Attributes
-											{
-												name="nato_trigger_Waffenwechsel1";
-												text="Trigger für Waffenwechsel-Dialog";
-												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
-												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=6.0710001;
-												sizeB=6.2379999;
-												sizeC=6.717;
-												repeatable=1;
-												activationBy="WEST";
-												isRectangle=1;
-											};
-											id=5263;
-											type="EmptyDetectorAreaR50";
-											atlOffset=0.76533318;
-										};
-										class Item3
-										{
-											dataType="Trigger";
-											position[]={33.487793,23.377258,16865.768};
-											angle=0.014784166;
-											class Attributes
-											{
-												name="trg_nato_repair_1";
-												text="Auslöser für Rep-Script";
-												condition="call{vehicle player in thislist && !isNull (objectParent player) && driver (vehicle player) == player && speed (vehicle player) < 0.1}";
-												onActivation="nul = [true] spawn opt_mission_fnc_repairSystem;";
-												onDeactivation="nul = [false] spawn opt_mission_fnc_repairSystem; ";
-												sizeA=5.2589998;
-												sizeB=5.1500001;
-												sizeC=8.2159996;
-												repeatable=1;
-												activationBy="WEST";
-												isRectangle=1;
-											};
-											id=5264;
-											type="EmptyDetectorArea10x10";
-											atlOffset=0.010404587;
-										};
-										class Item4
-										{
-											dataType="Trigger";
-											position[]={-0.34057617,24.042908,17020.736};
-											angle=6.2773957;
-											class Attributes
-											{
-												name="nato_trigger_beam";
-												text="Trigger für Beam-Dialog";
-												condition="call{this && vehicle player in thislist}";
-												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=5.4885349;
-												sizeB=6.2888346;
-												sizeC=2.3541203;
-												repeatable=1;
-												activationBy="WEST";
-												isRectangle=1;
-											};
-											id=5265;
-											type="EmptyDetectorAreaR50";
-											atlOffset=0.66238976;
-										};
-									};
-									id=220;
-									atlOffset=0.2160778;
-								};
-								class Item4
-								{
-									dataType="Layer";
-									name="N_basis";
-									class Entities
-									{
-										items=8;
-										class Item0
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={5.536377,23.366852,16931.439};
-												angles[]={0,1.5675942,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5266;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.10997;
-										};
-										class Item1
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={4.7365723,23.376984,16845.719};
-												angles[]={0,1.5666903,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5267;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.04066;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item2
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={6.3630371,23.366852,16891.008};
-												angles[]={0,1.5812434,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5268;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.03123;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item3
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={67.394409,23.366852,16979.98};
-												angles[]={0,4.6973944,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5269;
-											type="Land_HelipadCircle_F";
-											atlOffset=208.91786;
-										};
-										class Item4
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={14.007426,23.748383,16955.598};
-												angles[]={0,2.3564749,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												init="call{this addEventHandler [""ContainerClosed"", {params [""_container""]; clearWeaponCargoGlobal _container; clearMagazineCargoGlobal _container; clearItemCargoGlobal _container; clearBackpackCargoGlobal _container;  }]; this allowDamage false;}";
-											};
-											id=5270;
-											type="Box_NATO_Uniforms_F";
-											atlOffset=209.1631;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="ammoBox";
-													expression="[_this,_value] call bis_fnc_initAmmoBox;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"STRING"
-																};
-															};
-															value="[[[[],[]],[[],[]],[[],[]],[[],[]]],true]";
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item5
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={13.691772,27.344099,16958.492};
-												angles[]={0,4.7047024,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												skill=0.60000002;
-												init="call{this allowDamage false;  [this, west] spawn opt_mhq_fnc_init; this addAction [""<t color='#00ff00' size='1.25'>Beam-System benutzen</t>"", {[] call opt_beam_fnc_openDialog}, false, 5, false, true, """"]; }";
-												name="homeflag_west";
-											};
-											id=5271;
-											type="Flag_NATO_F";
-											atlOffset=0.00043869019;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item6
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={88.099731,23.651932,9392.3701};
-												angles[]={0,6.2229595,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5272;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.62193;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item7
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={5.9084473,23.367828,16786.268};
-												angles[]={0,3.1683886,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5273;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.12868;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-									};
-									id=228;
-									atlOffset=209.40875;
-								};
-								class Item5
-								{
-									dataType="Layer";
-									name="N_entfernungs_module";
-									id=248;
-									atlOffset=185.97;
-								};
-								class Item6
-								{
-									dataType="Layer";
-									name="N_bestell_tische";
-									class Entities
-									{
-										items=4;
-										class Item0
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-2.9244385,23.772034,16947.732};
-												angles[]={0,4.363255,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-											};
-											id=5274;
-											type="Land_CampingTable_small_F";
-											atlOffset=209.16078;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item1
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-4.7523193,23.772034,16904.857};
-												angles[]={0,3.3082838,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-											};
-											id=5275;
-											type="Land_CampingTable_small_F";
-											atlOffset=209.06665;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item2
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={76.476257,23.772034,16960.9};
-												angles[]={0,0.0081203263,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-											};
-											id=5276;
-											type="Land_CampingTable_small_F";
-											atlOffset=4.196167e-005;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item3
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-4.34021,23.782288,16828.715};
-												angles[]={0,0.16965744,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-											};
-											id=5277;
-											type="Land_CampingTable_small_F";
-											atlOffset=209.0688;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-									};
-									id=267;
-									atlOffset=0.0051250458;
-								};
-								class Item7
-								{
-									dataType="Layer";
-									name="N_bestell_laptops";
-									class Entities
-									{
-										items=5;
-										class Item0
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-4.4182129,24.346167,16828.623};
-												angles[]={0,3.0705643,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Luftwaffe"", ""choppers"", west]]}";
-												disableSimulation=1;
-											};
-											id=5278;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=1.9073486e-006;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item1
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-3.0036621,24.335928,16947.6};
-												angles[]={0,0.98132873,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Panzer"", ""armored"", west]]}";
-												disableSimulation=1;
-											};
-											id=5279;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=1.7166138e-005;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item2
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-4.8724365,24.335928,16904.904};
-												angles[]={0,6.2095761,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Nachschub"", ""supplies"", west]]}";
-												disableSimulation=1;
-											};
-											id=5280;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=1.7166138e-005;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item3
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={76.409424,24.335928,16960.887};
-												angles[]={0,2.9091537,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Rad-Fahrzeuge"", ""vehicles"", west]]}";
-												disableSimulation=1;
-											};
-											id=5281;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=1.7166138e-005;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item4
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-4.3984375,24.341522,16785.586};
-												angles[]={0,2.2728264,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Verkaufen"", ""sell"", west]]}";
-												disableSimulation=1;
-											};
-											id=5282;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=0.0043354034;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-									};
-									id=289;
-									atlOffset=0.80627251;
-								};
-								class Item8
-								{
-									dataType="Layer";
-									name="N_modelle";
-									class Entities
-									{
-										items=5;
-										class Item0
-										{
-											dataType="Group";
-											side="East";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={12.98877,23.36829,16969.527};
-														angles[]={0,1.7199113,0};
-													};
-													side="East";
-													flags=3;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5284;
-													type="OPT_CSAT_Besatzungsmitglied";
-													atlOffset=209.20148;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male03PER";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=0.95999998;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												combatMode="BLUE";
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5283;
-											atlOffset=209.20148;
-										};
-										class Item1
-										{
-											dataType="Group";
-											side="East";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={12.733643,23.323856,16964.371};
-														angles[]={0,0.83778566,0};
-													};
-													side="East";
-													flags=2;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5286;
-													type="OPT_CSAT_Scharfschuetze";
-													atlOffset=209.14363;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male03PER";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=0.95999998;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5285;
-											atlOffset=209.14363;
-										};
-										class Item2
-										{
-											dataType="Group";
-											side="East";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={13.148071,23.323856,16965.783};
-														angles[]={0,1.808952,0};
-													};
-													side="East";
-													flags=2;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5288;
-													type="OPT_CSAT_Grenadier";
-													atlOffset=209.14685;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male03PER";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=0.95999998;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5287;
-											atlOffset=209.14685;
-										};
-										class Item3
-										{
-											dataType="Group";
-											side="East";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={13.010742,23.323856,16968.119};
-														angles[]={0,1.2260385,0};
-													};
-													side="East";
-													flags=2;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5290;
-													type="OPT_CSAT_Pilot";
-													atlOffset=209.15326;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male03PER";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=0.95999998;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5289;
-											atlOffset=209.15326;
-										};
-										class Item4
-										{
-											dataType="Group";
-											side="East";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={13.261841,23.323917,16967.02};
-														angles[]={0,1.4821384,0};
-													};
-													side="East";
-													flags=3;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-														stance="Middle";
-														class Inventory
-														{
-															map="ItemMap";
-															compass="ItemCompass";
-															watch="ItemWatch";
-															radio="tf_fadak";
-															gps="ItemGPS";
-															headgear="H_StrawHat";
-														};
-													};
-													id=5292;
-													type="OPT_CSAT_Besatzungsmitglied";
-													atlOffset=209.15005;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male03PER";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=0.95999998;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5291;
-											atlOffset=209.15005;
-										};
-									};
-									id=295;
-									atlOffset=209.15326;
-								};
-							};
-							id=1;
-							atlOffset=209.24139;
-						};
-						class Item2
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={14.654901,24.191727,16951.545};
-								angles[]={0,0.94425803,0};
-							};
-							side="Empty";
-							class Attributes
-							{
-							};
-							id=5251;
-							type="OPT_B_CargoNet_01_ammo_F";
-							atlOffset=209.151;
-							class CustomAttributes
-							{
-								class Attribute0
-								{
-									property="ammoBox";
-									expression="[_this,_value] call bis_fnc_initAmmoBox;";
-									class Value
-									{
-										class data
-										{
-											class type
-											{
-												type[]=
-												{
-													"STRING"
-												};
-											};
-											value="[[[[""OPT_hgun_P07_F""],[70]],[[""Laserbatteries""],[50]],[[""optic_ACO_grn_smg"",""optic_Aco_smg"",""optic_Holosight_smg_blk_F"",""optic_ACO_grn"",""optic_Aco"",""optic_Holosight_blk_F"",""optic_Arco_blk_F"",""optic_Hamr"",""optic_MRCO"",""optic_ERCO_blk_F"",""acc_flashlight"",""acc_pointer_IR"",""ACE_DefusalKit"",""ACE_wirecutter"",""NVGoggles""],[50,50,50,50,50,50,50,50,50,50,50,50,20,10,70]],[[""B_AssaultPack_rgr"",""TFAR_rt1523g_big_bwmod"",""ACE_TacticalLadder_Pack"",""B_Parachute""],[25,25,10,60]]],false]";
-										};
-									};
-								};
-								nAttributes=1;
-							};
-						};
-					};
-					id=0;
-					atlOffset=184.17836;
-				};
-				class Item1
-				{
-					dataType="Layer";
-					name="CSAT_Brueckenkopf_Base ";
-					class Entities
-					{
-						items=3;
-						class Item0
-						{
-							dataType="Layer";
-							name="C_basismodul";
-							class Entities
-							{
-								items=8;
-								class Item0
-								{
-									dataType="Layer";
-									name="C_sicherh_zonen";
-									class Entities
-									{
-										items=2;
-										class Item0
-										{
-											dataType="Trigger";
-											position[]={48.77356,-132.17648,9112.2959};
-											angle=0.9986859;
-											class Attributes
-											{
-												text="NATO Todeszone";
-												condition="vehicle player in thisList";
-												onActivation="{player setDamage 1} foreach thisList; systemChat ""Ein NATO Spieler wurde auf Grund des Betretens der feindlichen Basis automatisch getötet!""";
-												sizeA=3000;
-												sizeB=3000;
-												timeout[]={10,10,10};
-												interuptable=1;
-												repeatable=1;
-												activationBy="WEST";
-											};
-											id=5293;
-											type="EmptyDetector";
-											atlOffset=53.793518;
-										};
-										class Item1
-										{
-											dataType="Trigger";
-											position[]={48.713013,0,9111.0459};
-											angle=3.5039749;
-											class Attributes
-											{
-												text="befriedeter Bereich";
-												condition="call{vehicle player in thisList}";
-												onActivation="call{systemChat ""Sie bewegen sich in Richtung der Feindbasis! Sofort abdrehen!""}";
-												sizeA=3500;
-												sizeB=3500;
-												interuptable=1;
-												repeatable=1;
-												activationBy="WEST";
-											};
-											id=5294;
-											type="EmptyDetector";
-											atlOffset=185.97;
-										};
-									};
-									id=719;
-									atlOffset=119.88176;
-								};
-								class Item1
-								{
-									dataType="Layer";
-									name="C_auslöser";
-									class Entities
-									{
-										items=8;
-										class Item0
-										{
-											dataType="Trigger";
-											position[]={8412.4697,103.16354,25160.094};
-											angle=4.036458;
-											class Attributes
-											{
-												name="csat_trigger_beam_4";
-												text="Trigger für Beam-Dialog";
-												condition="call{this && vehicle player in thislist}";
-												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=0;
-												sizeB=0;
-												sizeC=0;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5150;
-											type="EmptyDetectorAreaR50";
-											atlOffset=-1.0339966;
-										};
-										class Item1
-										{
-											dataType="Trigger";
-											position[]={8413.4805,102.24931,25167.217};
-											angle=4.036458;
-											class Attributes
-											{
-												name="csat_trigger_beam_6";
-												text="Trigger für Beam-Dialog";
-												condition="call{this && vehicle player in thislist}";
-												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=0;
-												sizeB=0;
-												sizeC=0;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5151;
-											type="EmptyDetectorAreaR50";
-										};
-										class Item2
-										{
-											dataType="Trigger";
-											position[]={8412.5889,102.28828,25164.184};
-											angle=4.036458;
-											class Attributes
-											{
-												name="csat_trigger_beam_5";
-												text="Trigger für Beam-Dialog";
-												condition="call{this && vehicle player in thislist}";
-												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=0;
-												sizeB=0;
-												sizeC=0;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5152;
-											type="EmptyDetectorAreaR50";
-											atlOffset=-0.80500031;
-										};
-										class Item3
-										{
-											dataType="Trigger";
-											position[]={106.00598,23.664673,9155.4443};
-											angle=6.256443;
-											class Attributes
-											{
-												name="csat_trigger_beam_3";
-												text="Trigger für Beam-Dialog";
-												condition="call{this && vehicle player in thislist}";
-												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=4.3943043;
-												sizeB=4.939353;
-												sizeC=3.1158428;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5295;
-											type="EmptyDetectorAreaR50";
-											atlOffset=209.63467;
-										};
-										class Item4
-										{
-											dataType="Trigger";
-											position[]={102.451,23.651001,9181.6982};
-											angle=6.2275243;
-											class Attributes
-											{
-												name="csat_trigger_Waffenwechsel2";
-												text="Trigger für Waffenwechsel-Dialog";
-												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
-												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=4.447;
-												sizeB=4.4549999;
-												sizeC=2.4820001;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5296;
-											type="EmptyDetectorAreaR50";
-											atlOffset=209.621;
-										};
-										class Item5
-										{
-											dataType="Trigger";
-											position[]={128.87512,20.181885,9276.6689};
-											angle=6.2759027;
-											class Attributes
-											{
-												name="opt_warehouse_garbage_collector_6";
-												text="Löschbereich für Wracks Landebahn";
-												sizeA=200;
-												sizeB=500;
-												repeatable=1;
-												activationBy="ANY";
-												isRectangle=1;
-											};
-											id=5297;
-											type="EmptyDetectorAreaR50";
-											atlOffset=206.15189;
-										};
-										class Item6
-										{
-											dataType="Trigger";
-											position[]={69.389,23.388992,9328.5693};
-											angle=3.0947826;
-											class Attributes
-											{
-												name="csat_trigger_Waffenwechsel1";
-												text="Trigger für Waffenwechsel-Dialog";
-												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
-												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
-												sizeA=4;
-												sizeB=4.4679999;
-												sizeC=4.7280002;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5298;
-											type="EmptyDetectorAreaR50";
-											atlOffset=209.35899;
-										};
-										class Item7
-										{
-											dataType="Trigger";
-											position[]={69.404419,23.661713,9328.624};
-											angle=4.6813307;
-											class Attributes
-											{
-												name="trg_csat_repair_1";
-												text="Auslöser für Rep-Script";
-												condition="call{vehicle player in thislist && !isNull (objectParent player) && driver (vehicle player) == player && speed (vehicle player) < 0.1}";
-												onActivation="call{nul = [true] spawn opt_mission_fnc_repairSystem;}";
-												onDeactivation="nul = [false] spawn opt_mission_fnc_repairSystem;";
-												sizeA=5.1464071;
-												sizeB=4.7551084;
-												sizeC=6.6230001;
-												repeatable=1;
-												activationBy="EAST";
-												isRectangle=1;
-											};
-											id=5299;
-											type="EmptyDetectorArea10x10";
-											atlOffset=0.00073432922;
-										};
-									};
-									id=789;
-									atlOffset=211.59158;
-								};
-								class Item2
-								{
-									dataType="Layer";
-									name="C_basis";
-									class Entities
-									{
-										items=7;
-										class Item0
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={94.529419,23.651016,9246.0244};
-												angles[]={0,4.6844177,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5300;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.62102;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item1
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={95.375122,23.661163,9331.8623};
-												angles[]={0,4.6695437,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5301;
-											type="Land_HelipadCircle_F";
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item2
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={35.58606,23.651016,9196.542};
-												angles[]={0,1.5359862,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5302;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.62102;
-										};
-										class Item3
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={89.103638,27.627821,9220.3799};
-												angles[]={0,3.3024762,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-												init="call{this allowDamage false; [this, west] spawn opt_mhq_fnc_init;  this addAction [""<t color='#00ff00' size='1.25'>Beam-System benutzen</t>"", {[] call opt_beam_fnc_openDialog}, false, 5, false, true, """"]; }";
-												name="homeflag_east";
-											};
-											id=5303;
-											type="Flag_CSAT_F";
-											atlOffset=209.62102;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item4
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={90.629028,24.032913,9225.0479};
-												angles[]={0,0.78095102,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this addEventHandler [""ContainerClosed"", {params [""_container""]; clearWeaponCargoGlobal _container; clearMagazineCargoGlobal _container; clearItemCargoGlobal _container; clearBackpackCargoGlobal _container;  }]; this allowDamage false;}";
-											};
-											id=5304;
-											type="Box_NATO_Uniforms_F";
-											atlOffset=0.00036239624;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="ammoBox";
-													expression="[_this,_value] call bis_fnc_initAmmoBox;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"STRING"
-																};
-															};
-															value="[[[[],[]],[[],[]],[[],[]],[[],[]]],true]";
-														};
-													};
-												};
-												class Attribute1
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=2;
-											};
-										};
-										class Item5
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={95.08606,23.651016,9285.2549};
-												angles[]={0,4.6687627,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												skill=0.60000002;
-											};
-											id=5305;
-											type="Land_HelipadCircle_F";
-											atlOffset=209.62102;
-										};
-										class Item6
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={88.301003,24.476303,9223.4131};
-												angles[]={0,1.4925009,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												health=0.6761747;
-											};
-											id=5306;
-											type="OPT_O_CargoNet_01_ammo_F";
-											atlOffset=209.621;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="ammoBox";
-													expression="[_this,_value] call bis_fnc_initAmmoBox;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"STRING"
-																};
-															};
-															value="[[[[""OPT_hgun_Rook40_F""],[70]],[[],[]],[[""optic_ACO_grn_smg"",""optic_Aco_smg"",""optic_Holosight_smg_blk_F"",""optic_ACO_grn"",""optic_Aco"",""optic_Holosight_blk_F"",""optic_Arco_blk_F"",""optic_Hamr"",""optic_MRCO"",""optic_ERCO_blk_F"",""acc_flashlight"",""acc_pointer_IR"",""ACE_DefusalKit"",""ACE_wirecutter"",""NVGoggles_OPFOR""],[50,50,50,50,50,50,50,50,50,50,50,50,20,10,70]],[[""B_FieldPack_ocamo"",""TFAR_mr3000"",""ACE_TacticalLadder_Pack"",""B_Parachute""],[25,25,10,60]]],false]";
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-									};
-									id=797;
-									atlOffset=0.00019264221;
-								};
-								class Item3
-								{
-									dataType="Layer";
-									name="C_schilder";
-									id=820;
-									atlOffset=185.97;
-								};
-								class Item4
-								{
-									dataType="Layer";
-									name="C_modelle";
-									class Entities
-									{
-										items=5;
-										class Item0
-										{
-											dataType="Group";
-											side="West";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={90.248169,23.652958,9209.0693};
-														angles[]={0,3.7081361,0};
-													};
-													side="West";
-													flags=7;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5308;
-													type="OPT_NATO_Besatzungsmitglied";
-													atlOffset=0.00049972534;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=1.04;
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=4;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5307;
-											atlOffset=0.00049972534;
-										};
-										class Item1
-										{
-											dataType="Group";
-											side="West";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={89.877075,23.652958,9213.0537};
-														angles[]={0,4.0070982,0};
-													};
-													side="West";
-													flags=6;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5310;
-													type="OPT_NATO_Scharfschuetze";
-													atlOffset=0.00049972534;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male05ENG";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=1.04;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5309;
-											atlOffset=0.00049972534;
-										};
-										class Item2
-										{
-											dataType="Group";
-											side="West";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={90.027466,23.652958,9211.4834};
-														angles[]={0,4.9707503,0};
-													};
-													side="West";
-													flags=6;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5312;
-													type="OPT_NATO_Grenadier";
-													atlOffset=0.00049972534;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=1.04;
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=4;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5311;
-											atlOffset=0.00049972534;
-										};
-										class Item3
-										{
-											dataType="Group";
-											side="West";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={90.502075,23.652958,9207.3428};
-														angles[]={0,4.9707503,0};
-													};
-													side="West";
-													flags=6;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-													};
-													id=5314;
-													type="OPT_NATO_Pilot";
-													atlOffset=0.00049972534;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="speaker";
-															expression="_this setspeaker _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Male08ENG";
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=1.04;
-																};
-															};
-														};
-														class Attribute4
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=5;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5313;
-											atlOffset=0.00049972534;
-										};
-										class Item4
-										{
-											dataType="Group";
-											side="West";
-											class Entities
-											{
-												items=1;
-												class Item0
-												{
-													dataType="Object";
-													class PositionInfo
-													{
-														position[]={90.0802,23.652958,9210.1865};
-														angles[]={0,4.4358292,0};
-													};
-													side="West";
-													flags=7;
-													class Attributes
-													{
-														disableSimulation=1;
-														ignoreByDynSimulGrid=1;
-														stance="Middle";
-														class Inventory
-														{
-															map="ItemMap";
-															compass="ItemCompass";
-															watch="ItemWatch";
-															radio="tf_anprc152";
-															gps="ItemGPS";
-															headgear="H_StrawHat_dark";
-														};
-													};
-													id=5316;
-													type="OPT_NATO_Besatzungsmitglied";
-													atlOffset=0.00049972534;
-													class CustomAttributes
-													{
-														class Attribute0
-														{
-															property="allowDamage";
-															expression="_this allowdamage _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														class Attribute1
-														{
-															property="face";
-															expression="_this setface _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"STRING"
-																		};
-																	};
-																	value="Custom";
-																};
-															};
-														};
-														class Attribute2
-														{
-															property="pitch";
-															expression="_this setpitch _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"SCALAR"
-																		};
-																	};
-																	value=1.04;
-																};
-															};
-														};
-														class Attribute3
-														{
-															property="enableStamina";
-															expression="_this enablestamina _value;";
-															class Value
-															{
-																class data
-																{
-																	class type
-																	{
-																		type[]=
-																		{
-																			"BOOL"
-																		};
-																	};
-																	value=0;
-																};
-															};
-														};
-														nAttributes=4;
-													};
-												};
-											};
-											class Attributes
-											{
-												behaviour="CARELESS";
-												speedMode="LIMITED";
-											};
-											id=5315;
-											atlOffset=0.00049972534;
-										};
-									};
-									id=907;
-									atlOffset=0.00049972534;
-								};
-								class Item5
-								{
-									dataType="Layer";
-									name="C_bestell_laptops";
-									class Entities
-									{
-										items=5;
-										class Item0
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={102.37708,24.629776,9349.8994};
-												angles[]={0,5.4315987,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Luftwaffe"", ""choppers"", east]]}";
-												disableSimulation=1;
-											};
-											id=5317;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=0.81245232;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item1
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={105.44153,24.620575,9230.1748};
-												angles[]={0,4.6323819,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Panzer"", ""armored"", east]]}";
-												disableSimulation=1;
-											};
-											id=5318;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=1.9073486e-006;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item2
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={105.64661,24.620392,9272.6318};
-												angles[]={0,4.1770549,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Nachschub"", ""supplies"", east]]}";
-												disableSimulation=1;
-											};
-											id=5319;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=0.81330681;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item3
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={26.937622,24.620239,9214.1572};
-												angles[]={0,6.1521616,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Fahrzeuge"", ""vehicles"", east]]}";
-												disableSimulation=1;
-											};
-											id=5320;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=0.81315231;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item4
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={99.99231,24.623764,9392.4209};
-												angles[]={0,5.4955044,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-												init="call{this setVariable [""opt_warehouse_data"", [""Verkaufen"", ""sell"", east]]}";
-												disableSimulation=1;
-											};
-											id=5321;
-											type="Land_Laptop_unfolded_F";
-											atlOffset=0.0024280548;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-									};
-									id=901;
-									atlOffset=0.8053875;
-								};
-								class Item6
-								{
-									dataType="Layer";
-									name="C_bestell_tische";
-									class Entities
-									{
-										items=6;
-										class Item0
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={102.4259,24.066391,9349.7314};
-												angles[]={0,2.529844,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-											};
-											id=5322;
-											type="Land_CampingTable_small_F";
-											atlOffset=209.6312;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item1
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={105.46106,24.056702,9230.1006};
-												angles[]={0,1.2663169,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-											};
-											id=5323;
-											type="Land_CampingTable_small_F";
-											atlOffset=0.00048446655;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item2
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={105.71887,24.05658,9272.5791};
-												angles[]={0,0.46589518,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-											};
-											id=5324;
-											type="Land_CampingTable_small_F";
-											atlOffset=0.00036430359;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item3
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={26.925903,24.056458,9214.042};
-												angles[]={0,3.2494898,0};
-											};
-											side="Empty";
-											flags=4;
-											class Attributes
-											{
-											};
-											id=5325;
-											type="Land_CampingTable_small_F";
-											atlOffset=0.00024032593;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item4
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={100.10364,24.057465,9392.29};
-												angles[]={0,2.5934267,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-											};
-											id=5326;
-											type="Land_CampingTable_small_F";
-											atlOffset=209.62227;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-										class Item5
-										{
-											dataType="Object";
-											class PositionInfo
-											{
-												position[]={-4.4543457,23.773315,16785.605};
-												angles[]={0,5.8511882,0};
-											};
-											side="Empty";
-											class Attributes
-											{
-											};
-											id=5327;
-											type="Land_CampingTable_small_F";
-											atlOffset=209.1465;
-											class CustomAttributes
-											{
-												class Attribute0
-												{
-													property="allowDamage";
-													expression="_this allowdamage _value;";
-													class Value
-													{
-														class data
-														{
-															class type
-															{
-																type[]=
-																{
-																	"BOOL"
-																};
-															};
-															value=0;
-														};
-													};
-												};
-												nAttributes=1;
-											};
-										};
-									};
-									id=918;
-									atlOffset=209.48027;
-								};
-								class Item7
-								{
-									dataType="Marker";
-									position[]={82.494263,857.229,9210.0068};
-									name="respawn_east";
-									type="respawn_unknown";
-									colorName="ColorRed";
-									angle=1.769748;
-									id=5328;
-									atlOffset=833.578;
-								};
-							};
-							id=617;
-							atlOffset=625.052;
-						};
-						class Item1
-						{
-							dataType="Layer";
-							name="CSAT Marine Basen";
-							class Entities
-							{
-								items=7;
-								class Item0
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={257.53534,9.2123861,8912.3145};
-										angles[]={0,0.55526257,0};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-										aiRadarUsage=28025824;
-									};
-									id=5329;
-									type="Land_TyreBarrier_01_F";
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item1
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={257.64285,9.4568043,8912.3252};
-										angles[]={0,4.312746,0};
-									};
-									side="Empty";
-									class Attributes
-									{
-										skill=0.60000002;
-										init="call{this setVariable [""opt_warehouse_data"", [""Marine-Ausrüstung"", ""sea"", east]]}";
-									};
-									id=5330;
-									type="Land_InfoStand_V1_F";
-									atlOffset=194.85144;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="ObjectTextureCustom0";
-											expression="_this setObjectTextureGlobal [0,_value]";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="opt_core\bilder\csat_marine_ausruestung.paa";
-												};
-											};
-										};
-										class Attribute1
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=2;
-									};
-								};
-								class Item2
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={246.40555,0,8910.1436};
-										angles[]={0,1.5251756,0};
-									};
-									side="Empty";
-									class Attributes
-									{
-										skill=0.60000002;
-									};
-									id=5331;
-									type="Land_HelipadCircle_F";
-									atlOffset=185.97;
-								};
-								class Item3
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={7158.127,-19.035769,10937.408};
-										angles[]={0,5.930788,0};
-									};
-									side="Empty";
-									flags=5;
-									class Attributes
-									{
-									};
-									id=5332;
-									type="Land_PierWooden_02_16m_F";
-									atlOffset=-1.8921239;
-								};
-								class Item4
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={8370.7148,42.61998,25288.645};
-										angles[]={0,1.8048995,0};
-									};
-									side="Empty";
-									flags=5;
-									class Attributes
-									{
-									};
-									id=5333;
-									type="Land_PierWooden_02_16m_F";
-								};
-								class Item5
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={7161.8618,-16.906258,10926.599};
-										angles[]={0,4.3552275,0};
-									};
-									side="Empty";
-									flags=5;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5334;
-									type="Land_PierWooden_02_hut_F";
-									atlOffset=-1.127049;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item6
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={8359.6406,43.210129,25291.521};
-										angles[]={0,0.22928907,0};
-									};
-									side="Empty";
-									flags=5;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5335;
-									type="Land_PierWooden_02_hut_F";
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-							};
-							id=3551;
-							atlOffset=-106.69644;
-						};
-						class Item2
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={8462.1914,101.42706,25164.809};
-								angles[]={0.23806481,5.3488054,0.1141679};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-								name="OPT_radar_containerEast";
-								presenceCondition="OPT_radar_on";
-							};
-							id=2741;
-							type="OPT_Land_Pod_Heli_Transport_04_repair_radar_F";
-							atlOffset=-0.11037445;
-							class CustomAttributes
-							{
-								class Attribute0
-								{
-									property="ammoBox";
-									expression="[_this,_value] call bis_fnc_initAmmoBox;";
-									class Value
-									{
-										class data
-										{
-											class type
-											{
-												type[]=
-												{
-													"STRING"
-												};
-											};
-											value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
-										};
-									};
-								};
-								nAttributes=1;
-							};
-						};
-					};
-					id=616;
-					atlOffset=-41.858688;
-				};
-				class Item2
 				{
 					dataType="Layer";
 					name="SM_mit_Beobachter";
@@ -20161,7 +16493,7 @@ class Mission
 					id=2178;
 					atlOffset=0.086212158;
 				};
-				class Item3
+				class Item1
 				{
 					dataType="Layer";
 					name="blufor";
@@ -20180,8 +16512,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={65.765015,23.379246,16940.232};
-										angles[]={0,1.7204443,0};
+										position[]={24772.518,23.379292,12971.168};
+										angles[]={0,3.3353119,0};
 									};
 									side="West";
 									flags=7;
@@ -20281,7 +16613,7 @@ class Mission
 									};
 									id=5337;
 									type="OPT_NATO_Offizier";
-									atlOffset=2.8610229e-005;
+									atlOffset=2.6702881e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20313,7 +16645,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5336;
-							atlOffset=2.8610229e-005;
+							atlOffset=2.6702881e-005;
 						};
 						class Item1
 						{
@@ -20327,8 +16659,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={66.598511,23.379246,16944.816};
-										angles[]={0,1.477962,0};
+										position[]={24777.059,23.379292,12970.132};
+										angles[]={0,3.0928297,0};
 									};
 									side="West";
 									flags=3;
@@ -20428,7 +16760,7 @@ class Mission
 									};
 									id=5339;
 									type="OPT_NATO_Offizier";
-									atlOffset=208.74191;
+									atlOffset=209.47139;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20461,7 +16793,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5338;
-							atlOffset=208.74191;
+							atlOffset=209.47139;
 						};
 						class Item2
 						{
@@ -20475,8 +16807,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={71.926636,23.379246,16948.422};
-										angles[]={0,4.4991207,0};
+										position[]={24780.426,23.379292,12964.65};
+										angles[]={0,6.1139903,0};
 									};
 									side="West";
 									flags=3;
@@ -20556,7 +16888,7 @@ class Mission
 									};
 									id=5341;
 									type="OPT_NATO_Gruppenfuehrer";
-									atlOffset=208.68794;
+									atlOffset=209.44444;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20586,8 +16918,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.726074,23.379246,16947.443};
-										angles[]={0,4.5395441,0};
+										position[]={24779.283,23.379292,12960.897};
+										angles[]={0,6.1544137,0};
 									};
 									side="West";
 									flags=1;
@@ -20675,7 +17007,7 @@ class Mission
 									};
 									id=5342;
 									type="OPT_NATO_LMG_Schuetze";
-									atlOffset=208.62688;
+									atlOffset=209.45358;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20705,8 +17037,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.152588,23.379246,16947.363};
-										angles[]={0,4.527235,0};
+										position[]={24779.27,23.379292,12962.475};
+										angles[]={0,6.1421046,0};
 									};
 									side="West";
 									flags=1;
@@ -20795,7 +17127,7 @@ class Mission
 									};
 									id=5343;
 									type="OPT_NATO_Sanitaeter";
-									atlOffset=208.6512;
+									atlOffset=209.45369;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20825,8 +17157,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={73.863892,23.379246,16949.295};
-										angles[]={0,4.527235,0};
+										position[]={24781.215,23.379292,12962.681};
+										angles[]={0,6.1421046,0};
 									};
 									side="West";
 									flags=1;
@@ -20915,7 +17247,7 @@ class Mission
 									};
 									id=5344;
 									type="OPT_NATO_Sanitaeter";
-									atlOffset=208.66792;
+									atlOffset=209.43813;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20945,156 +17277,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.542236,23.379246,16949.412};
-										angles[]={0,4.5948048,0};
-									};
-									side="West";
-									flags=1;
-									class Attributes
-									{
-										init="call{ (group this) setGroupIdGlobal [""Alpha""];}";
-										name="nato_lat";
-										description="leichte Panzerabwehr@Alpha";
-										isPlayable=1;
-										class Inventory
-										{
-											class primaryWeapon
-											{
-												name="OPT_arifle_SPAR_01_blk_F";
-												optics="optic_Aco";
-												muzzle="ACE_muzzle_mzls_L";
-												flashlight="acc_pointer_IR";
-												class primaryMuzzleMag
-												{
-													name="30Rnd_556x45_Stanag";
-													ammoLeft=30;
-												};
-											};
-											class secondaryWeapon
-											{
-												name="OPT_launch_B_RPG32_F";
-												class primaryMuzzleMag
-												{
-													name="RPG32_F";
-													ammoLeft=1;
-												};
-											};
-											class binocular
-											{
-												name="Rangefinder";
-											};
-											class uniform
-											{
-												typeName="U_B_CTRG_1";
-												isBackpack=0;
-												class MagazineCargo
-												{
-													items=1;
-													class Item0
-													{
-														name="30Rnd_556x45_Stanag";
-														count=2;
-														ammoLeft=30;
-													};
-												};
-											};
-											class vest
-											{
-												typeName="OPT_V_PlateCarrierL_CTRG";
-												isBackpack=0;
-												class MagazineCargo
-												{
-													items=3;
-													class Item0
-													{
-														name="HandGrenade";
-														count=2;
-														ammoLeft=1;
-													};
-													class Item1
-													{
-														name="SmokeShell";
-														count=2;
-														ammoLeft=1;
-													};
-													class Item2
-													{
-														name="30Rnd_556x45_Stanag";
-														count=2;
-														ammoLeft=30;
-													};
-												};
-											};
-											class backpack
-											{
-												typeName="B_ViperHarness_khk_F";
-												isBackpack=1;
-												class MagazineCargo
-												{
-													items=3;
-													class Item0
-													{
-														name="RPG32_F";
-														count=1;
-														ammoLeft=1;
-													};
-													class Item1
-													{
-														name="HandGrenade";
-														count=1;
-														ammoLeft=1;
-													};
-													class Item2
-													{
-														name="SmokeShell";
-														count=1;
-														ammoLeft=1;
-													};
-												};
-											};
-											map="ItemMap";
-											compass="ItemCompass";
-											watch="ItemWatch";
-											radio="tf_anprc152";
-											gps="ItemGPS";
-											goggles="G_Combat";
-											headgear="OPT_H_HelmetB_grass";
-										};
-									};
-									id=5345;
-									type="OPT_NATO_PA_Schuetze";
-									atlOffset=208.64345;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="pitch";
-											expression="_this setpitch _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"SCALAR"
-														};
-													};
-													value=0.97000003;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item5
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={77.238892,23.379246,16948.512};
-										angles[]={0,4.5619192,0};
+										position[]={24780.283,23.379292,12959.346};
+										angles[]={0,6.1767888,0};
 									};
 									side="West";
 									class Attributes
@@ -21167,7 +17351,7 @@ class Mission
 									};
 									id=5346;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.60576;
+									atlOffset=209.44502;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21192,13 +17376,13 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item6
+								class Item5
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.637573,23.379246,16948.475};
-										angles[]={0,4.5619235,0};
+										position[]={24780.314,23.379292,12960.938};
+										angles[]={0,6.1767931,0};
 									};
 									side="West";
 									class Attributes
@@ -21271,7 +17455,7 @@ class Mission
 									};
 									id=5347;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.63541;
+									atlOffset=209.44534;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21296,13 +17480,13 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item7
+								class Item6
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={73.999634,23.379246,16948.275};
-										angles[]={0,4.5257187,0};
+										position[]={24780.188,23.379292,12962.59};
+										angles[]={0,6.1405883,0};
 									};
 									side="West";
 									flags=1;
@@ -21417,7 +17601,7 @@ class Mission
 									};
 									id=5348;
 									type="OPT_NATO_Sprengmeister";
-									atlOffset=208.65932;
+									atlOffset=209.44635;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21442,20 +17626,20 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item8
+								class Item7
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.319214,23.379246,16947.301};
-										angles[]={0,4.4689255,0};
+										position[]={24779.268,23.379368,12959.132};
+										angles[]={0,6.0837989,0};
 									};
 									side="West";
 									class Attributes
 									{
 										init="call{ (group this) setGroupIdGlobal [""Alpha""];}";
 										name="nato_maaws";
-										description="MAAWS-Schütze@Alpha";
+										description="Light AT-Schütze@Alpha";
 										isPlayable=1;
 										class Inventory
 										{
@@ -21469,15 +17653,6 @@ class Mission
 												{
 													name="30Rnd_556x45_Stanag";
 													ammoLeft=30;
-												};
-											};
-											class secondaryWeapon
-											{
-												name="launch_MRAWS_olive_rail_F";
-												class primaryMuzzleMag
-												{
-													name="MRAWS_HEAT_F";
-													ammoLeft=1;
 												};
 											};
 											class binocular
@@ -21524,16 +17699,6 @@ class Mission
 											{
 												typeName="B_ViperHarness_khk_F";
 												isBackpack=1;
-												class MagazineCargo
-												{
-													items=1;
-													class Item0
-													{
-														name="MRAWS_HEAT_F";
-														count=1;
-														ammoLeft=1;
-													};
-												};
 											};
 											map="ItemMap";
 											compass="ItemCompass";
@@ -21546,7 +17711,7 @@ class Mission
 									};
 									id=5349;
 									type="OPT_NATO_PA_Schuetze";
-									atlOffset=208.59619;
+									atlOffset=209.45256;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21571,13 +17736,13 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item9
+								class Item8
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.247192,23.379246,16949.637};
-										angles[]={0,4.5386181,0};
+										position[]={24781.781,23.379368,12961.125};
+										angles[]={0,6.1534877,0};
 									};
 									side="West";
 									flags=1;
@@ -21651,7 +17816,7 @@ class Mission
 									};
 									id=5350;
 									type="OPT_NATO_Beobachter";
-									atlOffset=208.6131;
+									atlOffset=209.43367;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21695,6 +17860,124 @@ class Mission
 										nAttributes=2;
 									};
 								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={24781.703,-0.31692052,12959.489};
+									};
+									side="West";
+									flags=1;
+									class Attributes
+									{
+										init="call{ (group this) setGroupIdGlobal [""Alpha""];}";
+										name="lat";
+										description="Heavy AT-Schütze@Alpha";
+										isPlayable=1;
+										class Inventory
+										{
+											class primaryWeapon
+											{
+												name="OPT_arifle_SPAR_01_blk_F";
+												optics="optic_Aco";
+												flashlight="acc_pointer_IR";
+												class primaryMuzzleMag
+												{
+													name="30Rnd_556x45_Stanag";
+													ammoLeft=30;
+												};
+											};
+											class binocular
+											{
+												name="Rangefinder";
+											};
+											class uniform
+											{
+												typeName="U_B_CTRG_1";
+												isBackpack=0;
+												class MagazineCargo
+												{
+													items=1;
+													class Item0
+													{
+														name="30Rnd_556x45_Stanag";
+														count=2;
+														ammoLeft=30;
+													};
+												};
+												class ItemCargo
+												{
+													items=1;
+													class Item0
+													{
+														name="FirstAidKit";
+														count=2;
+													};
+												};
+											};
+											class vest
+											{
+												typeName="OPT_V_PlateCarrierL_CTRG";
+												isBackpack=0;
+												class MagazineCargo
+												{
+													items=2;
+													class Item0
+													{
+														name="HandGrenade";
+														count=2;
+														ammoLeft=1;
+													};
+													class Item1
+													{
+														name="SmokeShell";
+														count=2;
+														ammoLeft=1;
+													};
+												};
+											};
+											class backpack
+											{
+												typeName="B_TacticalPack_blk";
+												isBackpack=1;
+											};
+											map="ItemMap";
+											compass="ItemCompass";
+											watch="ItemWatch";
+											radio="tf_anprc152";
+											gps="ItemGPS";
+											goggles="G_Tactical_Black";
+											headgear="OPT_H_HelmetB_grass";
+										};
+									};
+									id=8183;
+									type="OPT_NATO_PA_Schuetze_Heavy";
+									atlOffset=185.73801;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="pitch";
+											expression="_this setpitch _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0.98000002;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
 							};
 							class Attributes
 							{
@@ -21702,7 +17985,7 @@ class Mission
 								behaviour="CARELESS";
 							};
 							id=5340;
-							atlOffset=208.68794;
+							atlOffset=209.44444;
 						};
 						class Item3
 						{
@@ -21716,8 +17999,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={72.089355,23.379246,16943.789};
-										angles[]={0,4.6821184,0};
+										position[]={24775.791,23.379292,12964.693};
+										angles[]={0,0.013802528,0};
 									};
 									side="West";
 									flags=3;
@@ -21797,7 +18080,7 @@ class Mission
 									};
 									id=5352;
 									type="OPT_NATO_Gruppenfuehrer";
-									atlOffset=208.6571;
+									atlOffset=209.48152;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21827,8 +18110,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.215698,23.379246,16942.959};
-										angles[]={0,4.7215624,0};
+										position[]={24774.871,23.379292,12962.608};
+										angles[]={0,0.053246498,0};
 									};
 									side="West";
 									flags=1;
@@ -21918,7 +18201,7 @@ class Mission
 									};
 									id=5353;
 									type="OPT_NATO_Besatzungsmitglied";
-									atlOffset=208.62149;
+									atlOffset=209.48888;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -21948,8 +18231,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.835327,23.379246,16942.643};
-										angles[]={0,4.7040949,0};
+										position[]={24774.479,23.379292,12961.004};
+										angles[]={0,0.035778999,0};
 									};
 									side="West";
 									flags=1;
@@ -22059,7 +18342,7 @@ class Mission
 									};
 									id=5354;
 									type="OPT_NATO_Pionier";
-									atlOffset=208.59283;
+									atlOffset=209.49202;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22089,8 +18372,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.259277,23.379246,16943.705};
-										angles[]={0,4.7102356,0};
+										position[]={24775.607,23.379292,12962.526};
+										angles[]={0,0.041919708,0};
 									};
 									side="West";
 									flags=1;
@@ -22179,7 +18462,7 @@ class Mission
 									};
 									id=5355;
 									type="OPT_NATO_Sanitaeter";
-									atlOffset=208.62538;
+									atlOffset=209.48299;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22209,8 +18492,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.844727,23.379246,16944.633};
-										angles[]={0,4.741271,0};
+										position[]={24776.467,23.379292,12960.904};
+										angles[]={0,0.072955132,0};
 									};
 									side="West";
 									flags=1;
@@ -22309,7 +18592,7 @@ class Mission
 									};
 									id=5356;
 									type="OPT_NATO_Grenadier";
-									atlOffset=208.60593;
+									atlOffset=209.47612;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22339,8 +18622,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.208862,23.379246,16944.584};
-										angles[]={0,4.744916,0};
+										position[]={24776.492,23.379292,12962.538};
+										angles[]={0,0.076600075,0};
 									};
 									side="West";
 									class Attributes
@@ -22413,7 +18696,7 @@ class Mission
 									};
 									id=5357;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.63191;
+									atlOffset=209.47591;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22443,8 +18726,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.454712,23.379246,16942.555};
-										angles[]={0,4.7482672,0};
+										position[]={24774.318,23.379292,12959.386};
+										angles[]={0,0.079950809,0};
 									};
 									side="West";
 									flags=1;
@@ -22544,7 +18827,7 @@ class Mission
 									};
 									id=5358;
 									type="OPT_NATO_Luftabwehrspezialist";
-									atlOffset=208.56201;
+									atlOffset=209.49242;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22574,8 +18857,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.05957,23.379246,16943.631};
-										angles[]={0,4.7066956,0};
+										position[]={24775.459,23.379292,12960.734};
+										angles[]={0,0.038379669,0};
 									};
 									side="West";
 									flags=1;
@@ -22656,7 +18939,7 @@ class Mission
 									};
 									id=5359;
 									type="OPT_NATO_MG_Schuetze";
-									atlOffset=208.59523;
+									atlOffset=209.48418;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22686,8 +18969,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.473999,23.378788,16944.479};
-										angles[]={0,4.7931628,0};
+										position[]={24776.242,23.378834,12959.283};
+										angles[]={0,0.12484694,0};
 									};
 									side="West";
 									flags=1;
@@ -22778,7 +19061,7 @@ class Mission
 									};
 									id=5360;
 									type="OPT_NATO_Scharfschuetze";
-									atlOffset=208.57401;
+									atlOffset=209.47644;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -22827,8 +19110,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.448746,23.384729,16943.559};
-										angles[]={0,4.6215448,0};
+										position[]={24775.324,23.384775,12959.353};
+										angles[]={0,6.2364144,0};
 									};
 									side="West";
 									flags=5;
@@ -22995,7 +19278,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5351;
-							atlOffset=208.6571;
+							atlOffset=209.48152;
 						};
 						class Item4
 						{
@@ -23009,8 +19292,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={71.758423,23.379246,16939.145};
-										angles[]={0,4.5790062,0};
+										position[]={24771.164,23.379292,12965.23};
+										angles[]={0,6.1938753,0};
 									};
 									side="West";
 									flags=3;
@@ -23090,7 +19373,7 @@ class Mission
 									};
 									id=5362;
 									type="OPT_NATO_Gruppenfuehrer";
-									atlOffset=208.63719;
+									atlOffset=209.52565;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23120,8 +19403,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.726563,23.379246,16938.734};
-										angles[]={0,4.6194277,0};
+										position[]={24770.582,23.379292,12961.281};
+										angles[]={0,6.2342973,0};
 									};
 									side="West";
 									flags=1;
@@ -23209,7 +19492,7 @@ class Mission
 									};
 									id=5363;
 									type="OPT_NATO_LMG_Schuetze";
-									atlOffset=208.57292;
+									atlOffset=209.53342;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23239,8 +19522,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.769653,23.379246,16939.809};
-										angles[]={0,4.6194277,0};
+										position[]={24771.65,23.379292,12961.19};
+										angles[]={0,6.2342973,0};
 									};
 									side="West";
 									flags=1;
@@ -23328,7 +19611,7 @@ class Mission
 									};
 									id=5364;
 									type="OPT_NATO_LMG_Schuetze";
-									atlOffset=208.57779;
+									atlOffset=209.51917;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23358,8 +19641,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.011597,23.379246,16938.045};
-										angles[]={0,4.6071224,0};
+										position[]={24769.967,23.379292,12963.027};
+										angles[]={0,6.221992,0};
 									};
 									side="West";
 									flags=1;
@@ -23448,7 +19731,7 @@ class Mission
 									};
 									id=5365;
 									type="OPT_NATO_Sanitaeter";
-									atlOffset=208.59828;
+									atlOffset=209.54163;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23478,8 +19761,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.707886,23.379246,16937.922};
-										angles[]={0,4.6071224,0};
+										position[]={24769.771,23.379292,12961.338};
+										angles[]={0,6.221992,0};
 									};
 									side="West";
 									flags=1;
@@ -23568,7 +19851,7 @@ class Mission
 									};
 									id=5366;
 									type="OPT_NATO_Sanitaeter";
-									atlOffset=208.56895;
+									atlOffset=209.5442;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23598,8 +19881,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.527222,23.379246,16938.848};
-										angles[]={0,4.6418018,0};
+										position[]={24770.613,23.379292,12959.476};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -23672,7 +19955,7 @@ class Mission
 									};
 									id=5367;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.53751;
+									atlOffset=209.53224;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23702,8 +19985,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={73.893066,23.379246,16938.877};
-										angles[]={0,4.6056042,0};
+										position[]={24770.801,23.379292,12963.111};
+										angles[]={0,6.2204738,0};
 									};
 									side="West";
 									flags=1;
@@ -23818,7 +20101,7 @@ class Mission
 									};
 									id=5368;
 									type="OPT_NATO_Sprengmeister";
-									atlOffset=208.60445;
+									atlOffset=209.53049;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23848,8 +20131,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.517944,23.379246,16939.953};
-										angles[]={0,4.6056042,0};
+										position[]={24771.719,23.379292,12959.438};
+										angles[]={0,6.2204738,0};
 									};
 									side="West";
 									flags=1;
@@ -23964,7 +20247,7 @@ class Mission
 									};
 									id=5369;
 									type="OPT_NATO_Sprengmeister";
-									atlOffset=208.54359;
+									atlOffset=209.51746;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -23994,8 +20277,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.199341,23.379246,16939.748};
-										angles[]={0,4.6381531,0};
+										position[]={24771.662,23.379292,12962.761};
+										angles[]={0,6.2530227,0};
 									};
 									side="West";
 									flags=1;
@@ -24109,7 +20392,7 @@ class Mission
 									};
 									id=5370;
 									type="OPT_NATO_Grenadier";
-									atlOffset=208.60461;
+									atlOffset=209.51901;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24139,8 +20422,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.426758,23.379246,16937.902};
-										angles[]={0,4.6418018,0};
+										position[]={24769.672,23.379292,12959.621};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -24213,7 +20496,7 @@ class Mission
 									};
 									id=5371;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.53448;
+									atlOffset=209.54498;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24246,7 +20529,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5361;
-							atlOffset=208.63719;
+							atlOffset=209.52565;
 						};
 						class Item5
 						{
@@ -24260,8 +20543,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={72.057617,23.379246,16934.814};
-										angles[]={0,4.6490459,0};
+										position[]={24766.822,23.379292,12965.122};
+										angles[]={0,6.2639155,0};
 									};
 									side="West";
 									flags=3;
@@ -24341,7 +20624,7 @@ class Mission
 									};
 									id=5373;
 									type="OPT_NATO_Gruppenfuehrer";
-									atlOffset=208.6097;
+									atlOffset=209.58354;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24371,8 +20654,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.396729,23.379246,16933.465};
-										angles[]={0,4.6862736,0};
+										position[]={24765.375,23.379292,12962.842};
+										angles[]={0,0.017957687,0};
 									};
 									side="West";
 									flags=1;
@@ -24452,7 +20735,7 @@ class Mission
 									};
 									id=5374;
 									type="OPT_NATO_Operator";
-									atlOffset=208.56821;
+									atlOffset=209.60281;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24482,8 +20765,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.870117,23.379246,16933.268};
-										angles[]={0,4.6771622,0};
+										position[]={24765.113,23.379292,12961.381};
+										angles[]={0,0.008846283,0};
 									};
 									side="West";
 									flags=1;
@@ -24572,7 +20855,7 @@ class Mission
 									};
 									id=5375;
 									type="OPT_NATO_Sanitaeter";
-									atlOffset=208.54091;
+									atlOffset=209.60631;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24602,8 +20885,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.318115,23.379246,16934.422};
-										angles[]={0,4.7081947,0};
+										position[]={24766.336,23.379292,12962.88};
+										angles[]={0,0.039878845,0};
 									};
 									side="West";
 									flags=1;
@@ -24702,7 +20985,7 @@ class Mission
 									};
 									id=5376;
 									type="OPT_NATO_Grenadier";
-									atlOffset=208.57445;
+									atlOffset=209.59003;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24732,15 +21015,15 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.155396,23.379246,16935.428};
-										angles[]={0,4.6188526,0};
+										position[]={24767.482,23.379368,12962.877};
+										angles[]={0,6.2337222,0};
 									};
 									side="West";
 									class Attributes
 									{
 										init="call{ (group this) setGroupIdGlobal [""Adler""];}";
 										name="nato_maaws_1";
-										description="MAAWS-Schütze@Adler";
+										description="Light AT-Schütze@Adler";
 										isPlayable=1;
 										class Inventory
 										{
@@ -24754,15 +21037,6 @@ class Mission
 												{
 													name="30Rnd_556x45_Stanag";
 													ammoLeft=30;
-												};
-											};
-											class secondaryWeapon
-											{
-												name="launch_MRAWS_olive_rail_F";
-												class primaryMuzzleMag
-												{
-													name="MRAWS_HEAT_F";
-													ammoLeft=1;
 												};
 											};
 											class binocular
@@ -24809,16 +21083,6 @@ class Mission
 											{
 												typeName="B_ViperHarness_khk_F";
 												isBackpack=1;
-												class MagazineCargo
-												{
-													items=1;
-													class Item0
-													{
-														name="MRAWS_HEAT_F";
-														count=1;
-														ammoLeft=1;
-													};
-												};
 											};
 											map="ItemMap";
 											compass="ItemCompass";
@@ -24831,7 +21095,7 @@ class Mission
 									};
 									id=5377;
 									type="OPT_NATO_PA_Schuetze";
-									atlOffset=208.58221;
+									atlOffset=209.57483;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24861,8 +21125,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.044922,23.379246,16934.371};
-										angles[]={0,4.7151918,0};
+										position[]={24766.207,23.379292,12961.156};
+										angles[]={0,0.046875954,0};
 									};
 									side="West";
 									flags=1;
@@ -24962,7 +21226,7 @@ class Mission
 									};
 									id=5378;
 									type="OPT_NATO_Luftabwehrspezialist";
-									atlOffset=208.54329;
+									atlOffset=209.59174;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -24992,8 +21256,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.148071,23.379246,16935.389};
-										angles[]={0,4.6885424,0};
+										position[]={24767.217,23.379292,12961.007};
+										angles[]={0,0.020226479,0};
 									};
 									side="West";
 									flags=1;
@@ -25067,7 +21331,7 @@ class Mission
 									};
 									id=5379;
 									type="OPT_NATO_Beobachter";
-									atlOffset=208.54665;
+									atlOffset=209.57829;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -25116,8 +21380,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.877998,23.379215,16935.383};
-										angles[]={0,4.7600889,0};
+										position[]={24767.141,23.379261,12959.28};
+										angles[]={0,0.091773033,0};
 									};
 									side="West";
 									flags=1;
@@ -25208,7 +21472,7 @@ class Mission
 									};
 									id=5380;
 									type="OPT_NATO_Scharfschuetze";
-									atlOffset=208.51199;
+									atlOffset=209.57823;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -25257,8 +21521,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={78.148438,23.385319,16932.873};
-										angles[]={0,4.6418018,0};
+										position[]={24764.615,23.385365,12959.118};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -25331,7 +21595,7 @@ class Mission
 									};
 									id=5382;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.4993;
+									atlOffset=209.6183;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -25361,8 +21625,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={78.0466,23.711037,16934.293};
-										angles[]={0,4.6215448,0};
+										position[]={24766.039,23.711082,12959.16};
+										angles[]={0,6.2364144,0};
 									};
 									side="West";
 									flags=1;
@@ -25497,7 +21761,7 @@ class Mission
 									};
 									id=6438;
 									type="OPT_NATO_Aufklaerung_JTAC";
-									atlOffset=0.32579803;
+									atlOffset=0.32579613;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -25529,7 +21793,7 @@ class Mission
 								behaviour="CARELESS";
 							};
 							id=5372;
-							atlOffset=208.6097;
+							atlOffset=209.58354;
 						};
 						class Item6
 						{
@@ -25543,8 +21807,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.49646,23.379246,16929.92};
-										angles[]={0,5.1331911,0};
+										position[]={24761.783,23.379292,12961.9};
+										angles[]={0,0.46487522,0};
 									};
 									side="West";
 									flags=3;
@@ -25642,7 +21906,7 @@ class Mission
 									};
 									id=5384;
 									type="OPT_NATO_Pilot";
-									atlOffset=208.5305;
+									atlOffset=209.65501;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -25694,7 +21958,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5383;
-							atlOffset=208.5305;
+							atlOffset=209.65501;
 						};
 						class Item7
 						{
@@ -25708,8 +21972,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.156128,23.379246,16930.16};
-										angles[]={0,5.1331911,0};
+										position[]={24762.082,23.379292,12963.229};
+										angles[]={0,0.46487522,0};
 									};
 									side="West";
 									flags=3;
@@ -25807,7 +22071,7 @@ class Mission
 									};
 									id=5386;
 									type="OPT_NATO_Pilot";
-									atlOffset=208.55411;
+									atlOffset=209.65063;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -25859,7 +22123,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5385;
-							atlOffset=208.55411;
+							atlOffset=209.65063;
 						};
 						class Item8
 						{
@@ -25873,8 +22137,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.924683,23.379246,16929.852};
-										angles[]={0,5.1331911,0};
+										position[]={24761.65,23.379292,12960.476};
+										angles[]={0,0.46487522,0};
 									};
 									side="West";
 									flags=3;
@@ -25972,7 +22236,7 @@ class Mission
 									};
 									id=5388;
 									type="OPT_NATO_Pilot";
-									atlOffset=208.50159;
+									atlOffset=209.65697;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26024,7 +22288,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5387;
-							atlOffset=208.50159;
+							atlOffset=209.65697;
 						};
 						class Item9
 						{
@@ -26038,8 +22302,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={71.983765,23.379673,16951.959};
-										angles[]={0,4.5727215,0};
+										position[]={24783.959,23.379719,12964.441};
+										angles[]={0,6.1875911,0};
 									};
 									side="West";
 									flags=3;
@@ -26119,7 +22383,7 @@ class Mission
 									};
 									id=5390;
 									type="OPT_NATO_Gruppenfuehrer";
-									atlOffset=208.70863;
+									atlOffset=209.41772;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26149,8 +22413,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={73.510376,23.379246,16951.07};
-										angles[]={0,4.6121664,0};
+										position[]={24783.002,23.379292,12962.951};
+										angles[]={0,6.227036,0};
 									};
 									side="West";
 									flags=1;
@@ -26240,7 +22504,7 @@ class Mission
 									};
 									id=5391;
 									type="OPT_NATO_Besatzungsmitglied";
-									atlOffset=208.68311;
+									atlOffset=209.42383;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26270,8 +22534,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={73.582397,23.379246,16951.934};
-										angles[]={0,4.6121664,0};
+										position[]={24783.859,23.379292,12962.846};
+										angles[]={0,6.227036,0};
 									};
 									side="West";
 									flags=1;
@@ -26361,7 +22625,7 @@ class Mission
 									};
 									id=5392;
 									type="OPT_NATO_Besatzungsmitglied";
-									atlOffset=208.68677;
+									atlOffset=209.41698;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26391,8 +22655,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={73.503052,23.379246,16952.922};
-										angles[]={0,4.6121664,0};
+										position[]={24784.85,23.379292,12962.877};
+										angles[]={0,6.227036,0};
 									};
 									side="West";
 									flags=1;
@@ -26482,7 +22746,7 @@ class Mission
 									};
 									id=5393;
 									type="OPT_NATO_Besatzungsmitglied";
-									atlOffset=208.69308;
+									atlOffset=209.40929;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26512,8 +22776,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.886353,23.379246,16951.357};
-										angles[]={0,4.5946951,0};
+										position[]={24783.227,23.379292,12961.565};
+										angles[]={0,6.2095647,0};
 									};
 									side="West";
 									flags=1;
@@ -26623,7 +22887,7 @@ class Mission
 									};
 									id=5394;
 									type="OPT_NATO_Pionier";
-									atlOffset=208.66629;
+									atlOffset=209.42203;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26653,8 +22917,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.022827,23.379246,16952.283};
-										angles[]={0,4.6318712,0};
+										position[]={24784.146,23.379292,12961.39};
+										angles[]={0,6.2467408,0};
 									};
 									side="West";
 									flags=1;
@@ -26753,7 +23017,7 @@ class Mission
 									};
 									id=5395;
 									type="OPT_NATO_Grenadier";
-									atlOffset=208.6693;
+									atlOffset=209.41467;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26783,8 +23047,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={75.167603,23.379246,16953.152};
-										angles[]={0,4.6418018,0};
+										position[]={24785.01,23.379292,12961.206};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -26857,7 +23121,7 @@ class Mission
 									};
 									id=5396;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.67122;
+									atlOffset=209.40776;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26887,8 +23151,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.837524,23.379246,16951.594};
-										angles[]={0,4.6418018,0};
+										position[]={24783.379,23.379292,12959.606};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -26961,7 +23225,7 @@ class Mission
 									};
 									id=5397;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.63174;
+									atlOffset=209.42081;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -26991,8 +23255,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.822021,23.379246,16953.453};
-										angles[]={0,4.6418018,0};
+										position[]={24785.236,23.379292,12959.54};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -27065,7 +23329,7 @@ class Mission
 									};
 									id=5398;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.64195;
+									atlOffset=209.40596;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27095,8 +23359,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.89917,23.379246,16952.475};
-										angles[]={0,4.6418018,0};
+										position[]={24784.256,23.379292,12959.505};
+										angles[]={0,6.2566714,0};
 									};
 									side="West";
 									class Attributes
@@ -27169,7 +23433,7 @@ class Mission
 									};
 									id=5399;
 									type="OPT_NATO_Soldat";
-									atlOffset=208.6353;
+									atlOffset=209.4138;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27202,13 +23466,13 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=5389;
-							atlOffset=208.70863;
+							atlOffset=209.41772;
 						};
 					};
 					id=2709;
-					atlOffset=208.62157;
+					atlOffset=209.50075;
 				};
-				class Item4
+				class Item2
 				{
 					dataType="Layer";
 					name="opfor";
@@ -27227,8 +23491,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={37.87262,23.280216,9226.8359};
-										angles[]={0,4.7214637,0};
+										position[]={14112.768,23.628422,12355.418};
+										angles[]={0,5.2700748,0};
 									};
 									side="East";
 									flags=3;
@@ -27312,7 +23576,7 @@ class Mission
 									};
 									id=6300;
 									type="OPT_CSAT_Offizier";
-									atlOffset=209.24878;
+									atlOffset=72.074646;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27363,7 +23627,7 @@ class Mission
 								behaviour="CARELESS";
 							};
 							id=6299;
-							atlOffset=209.24878;
+							atlOffset=72.074646;
 						};
 						class Item1
 						{
@@ -27377,8 +23641,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={29.18586,23.290546,9226.2803};
-										angles[]={0,1.5175114,0};
+										position[]={14224.896,23.290501,12433.526};
+										angles[]={0,2.066098,0};
 									};
 									side="East";
 									flags=3;
@@ -27472,7 +23736,7 @@ class Mission
 									};
 									id=6302;
 									type="OPT_CSAT_Pilot";
-									atlOffset=209.25911;
+									atlOffset=60.815544;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27521,8 +23785,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={26.668861,23.668369,9226.1143};
-										angles[]={0,1.4902668,0};
+										position[]={14222.662,23.668324,12434.699};
+										angles[]={0,2.0388532,0};
 									};
 									side="East";
 									flags=5;
@@ -27596,7 +23860,7 @@ class Mission
 									};
 									id=6303;
 									type="OPT_CSAT_Soldat";
-									atlOffset=0.00022506714;
+									atlOffset=0.0056800842;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27648,7 +23912,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=6301;
-							atlOffset=209.25911;
+							atlOffset=60.815544;
 						};
 						class Item2
 						{
@@ -27662,8 +23926,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={29.256859,23.280216,9224.1709};
-										angles[]={0,1.5241262,0};
+										position[]={14223.859,23.28017,12431.691};
+										angles[]={0,2.0727124,0};
 									};
 									side="East";
 									flags=3;
@@ -27757,7 +24021,7 @@ class Mission
 									};
 									id=6305;
 									type="OPT_CSAT_Pilot";
-									atlOffset=209.24878;
+									atlOffset=60.767792;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27806,8 +24070,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={26.691864,23.668369,9224.0342};
-										angles[]={0,1.4902843,0};
+										position[]={14221.596,23.668324,12432.912};
+										angles[]={0,2.0388708,0};
 									};
 									side="East";
 									flags=5;
@@ -27881,7 +24145,7 @@ class Mission
 									};
 									id=6306;
 									type="OPT_CSAT_Soldat";
-									atlOffset=0.00024604797;
+									atlOffset=0.0056591034;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -27933,7 +24197,7 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=6304;
-							atlOffset=209.24878;
+							atlOffset=60.767792;
 						};
 						class Item3
 						{
@@ -27947,8 +24211,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={32.064857,23.280216,9226.4531};
-										angles[]={0,1.5300255,0};
+										position[]={14227.445,23.28017,12432.175};
+										angles[]={0,2.0786116,0};
 									};
 									side="East";
 									flags=3;
@@ -28042,7 +24306,7 @@ class Mission
 									};
 									id=6308;
 									type="OPT_CSAT_Pilot";
-									atlOffset=209.24878;
+									atlOffset=61.370514;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -28091,8 +24355,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={32.151863,23.280216,9224.3047};
-										angles[]={0,1.5761195,0};
+										position[]={14226.398,23.28017,12430.298};
+										angles[]={0,2.1247063,0};
 									};
 									side="East";
 									flags=1;
@@ -28166,7 +24430,7 @@ class Mission
 									};
 									id=6309;
 									type="OPT_CSAT_Soldat";
-									atlOffset=209.24878;
+									atlOffset=61.548775;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -28218,26 +24482,26 @@ class Mission
 								speedMode="LIMITED";
 							};
 							id=6307;
-							atlOffset=209.24878;
+							atlOffset=61.370514;
 						};
 					};
 					id=2711;
-					atlOffset=209.25008;
+					atlOffset=59.245319;
 				};
-				class Item5
+				class Item3
 				{
 					dataType="Layer";
 					name="map_objekte_von_oppa";
 					class Entities
 					{
-						items=1;
+						items=8;
 						class Item0
 						{
 							dataType="Layer";
 							name="barikaden_kavala";
 							class Entities
 							{
-								items=368;
+								items=327;
 								class Item0
 								{
 									dataType="Object";
@@ -39766,539 +36030,6 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4309.481,30.915367,13884.498};
-										angles[]={0.015998369,5.8227415,0.046631888};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5765;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=0.0065574646;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item294
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4311.8906,31.044029,13883.073};
-										angles[]={0.013332055,5.8223457,0.049293593};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5766;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-2.4795532e-005;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item295
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4314.6553,31.21719,13881.41};
-										angles[]={0.02666023,6.0288301,0.049292382};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5767;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00016021729;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item296
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4317.1152,31.391354,13879.43};
-										angles[]={0.02666023,6.0296683,0.049292382};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5768;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00016593933;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item297
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4319.1465,31.542614,13877.516};
-										angles[]={0.02666023,6.0299702,0.049292382};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5769;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00015640259;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item298
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4324.7827,31.911255,13875.086};
-										angles[]={0.02666023,0.13367625,0.05461248};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5770;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00012207031;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item299
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4327.2651,32.226528,13870.714};
-										angles[]={0.041309625,0.13367625,0.054611389};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5771;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00036430359;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item300
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4330.5947,32.52002,13868.119};
-										angles[]={0.041309625,0.13053583,0.055941612};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5772;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00032234192;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item301
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4333.4258,32.90377,13864.325};
-										angles[]={0.062584557,0.34622046,0.055941612};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5773;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.0005531311;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item302
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4342.0693,35.920078,13842.268};
-										angles[]={0.19995849,0.34491622,6.276526};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5774;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.013683319;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item303
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4342.1309,34.624634,13849.822};
-										angles[]={0.14823791,0.3451046,0.059928458};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5775;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.0040512085;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item304
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4335.5801,33.18475,13861.732};
-										angles[]={0.062584557,0.13367625,0.051953323};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5776;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00017166138;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item305
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4338.1079,33.596977,13857.823};
-										angles[]={0.078504436,0.13053583,0.051953323};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=5777;
-									type="Land_CzechHedgehog_01_new_F";
-									atlOffset=-0.00012588501;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item306
-								{
-									dataType="Object";
-									class PositionInfo
-									{
 										position[]={3876.4087,7.7864547,14758.302};
 										angles[]={0.074527748,5.1391411,6.2738566};
 									};
@@ -40335,7 +36066,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item307
+								class Item294
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40376,7 +36107,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item308
+								class Item295
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40417,7 +36148,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item309
+								class Item296
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40458,7 +36189,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item310
+								class Item297
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40499,7 +36230,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item311
+								class Item298
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40540,7 +36271,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item312
+								class Item299
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40581,7 +36312,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item313
+								class Item300
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40622,7 +36353,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item314
+								class Item301
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40662,7 +36393,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item315
+								class Item302
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40703,7 +36434,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item316
+								class Item303
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40744,7 +36475,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item317
+								class Item304
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40785,7 +36516,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item318
+								class Item305
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40826,7 +36557,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item319
+								class Item306
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40867,7 +36598,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item320
+								class Item307
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40908,7 +36639,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item321
+								class Item308
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40949,7 +36680,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item322
+								class Item309
 								{
 									dataType="Object";
 									class PositionInfo
@@ -40990,7 +36721,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item323
+								class Item310
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41031,7 +36762,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item324
+								class Item311
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41072,7 +36803,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item325
+								class Item312
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41113,7 +36844,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item326
+								class Item313
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41154,7 +36885,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item327
+								class Item314
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41195,7 +36926,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item328
+								class Item315
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41236,7 +36967,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item329
+								class Item316
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41277,7 +37008,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item330
+								class Item317
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41318,7 +37049,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item331
+								class Item318
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41359,7 +37090,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item332
+								class Item319
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41400,7 +37131,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item333
+								class Item320
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41441,7 +37172,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item334
+								class Item321
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41482,7 +37213,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item335
+								class Item322
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41523,7 +37254,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item336
+								class Item323
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41564,7 +37295,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item337
+								class Item324
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41605,42 +37336,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item338
-								{
-									dataType="Marker";
-									position[]={3786.7969,22.09201,12714.915};
-									name="marker_32";
-									text="Ceckpoint Alpha";
-									type="loc_DangerousForces";
-									colorName="ColorWEST";
-									angle=358.95471;
-									id=5810;
-								};
-								class Item339
-								{
-									dataType="Marker";
-									position[]={3364.7251,4.2960052,12572.783};
-									name="marker_34";
-									text="Ceckpoint Bravo";
-									type="loc_DangerousForces";
-									colorName="ColorWEST";
-									angle=1.4907526;
-									id=5811;
-									atlOffset=-0.00017023087;
-								};
-								class Item340
-								{
-									dataType="Marker";
-									position[]={4274.9775,27.947754,13920.358};
-									name="marker_33";
-									text="Ceckpoint Charly";
-									type="loc_DangerousForces";
-									colorName="ColorWEST";
-									angle=1.7711376;
-									id=5812;
-									atlOffset=-0.69735909;
-								};
-								class Item341
+								class Item325
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41655,7 +37351,7 @@ class Mission
 									type="ATMine";
 									atlOffset=0.3234818;
 								};
-								class Item342
+								class Item326
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41670,7 +37366,11987 @@ class Mission
 									type="ATMine";
 									atlOffset=0.69763589;
 								};
-								class Item343
+							};
+							id=5471;
+							atlOffset=0.34582663;
+						};
+						class Item1
+						{
+							dataType="Layer";
+							name="chekpoint_marker";
+							class Entities
+							{
+								items=5;
+								class Item0
+								{
+									dataType="Layer";
+									name="Agios";
+									class Entities
+									{
+										items=26;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={9203.4023,137.34267,15825.155};
+											name="marker_50";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=186.30418;
+											id=6503;
+											atlOffset=16.355232;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={9237.5313,145.59267,15832.867};
+											name="marker_51";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=66.451088;
+											id=6504;
+											atlOffset=24.32621;
+										};
+										class Item2
+										{
+											dataType="Marker";
+											position[]={9208.8066,127.52292,15830.838};
+											name="marker_52";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=186.30418;
+											id=6518;
+											atlOffset=6.3593292;
+										};
+										class Item3
+										{
+											dataType="Marker";
+											position[]={9235.8857,145.72255,15825.214};
+											name="marker_53";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=157.22179;
+											id=6506;
+											atlOffset=23.312309;
+										};
+										class Item4
+										{
+											dataType="Marker";
+											position[]={9219.4902,147.70497,15843.531};
+											name="marker_54";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=157.22179;
+											id=6507;
+											atlOffset=26.214401;
+										};
+										class Item5
+										{
+											dataType="Marker";
+											position[]={9207.4043,128.44968,15818.433};
+											name="marker_55";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=186.30418;
+											id=6519;
+											atlOffset=7.5217743;
+										};
+										class Item6
+										{
+											dataType="Marker";
+											position[]={9218.3428,137.02704,15823.404};
+											name="marker_56";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=186.30418;
+											id=6520;
+											atlOffset=13.903732;
+										};
+										class Item7
+										{
+											dataType="Marker";
+											position[]={9222.6992,127.20728,15829.199};
+											name="marker_57";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=186.30418;
+											id=6521;
+											atlOffset=5.9844894;
+										};
+										class Item8
+										{
+											dataType="Marker";
+											position[]={9221.9951,127.8779,15822.976};
+											name="marker_58";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=186.30418;
+											id=6522;
+											atlOffset=6.7234421;
+										};
+										class Item9
+										{
+											dataType="Marker";
+											position[]={9225.9668,135.84537,15825.678};
+											name="marker_59";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=186.30418;
+											id=6523;
+											atlOffset=14.624313;
+										};
+										class Item10
+										{
+											dataType="Marker";
+											position[]={9225.0469,127.34958,15816.491};
+											name="marker_60";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=186.30418;
+											id=6526;
+											atlOffset=6.0385284;
+										};
+										class Item11
+										{
+											dataType="Marker";
+											position[]={9213.6689,129.39987,15817.732};
+											name="marker_61";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=186.30418;
+											id=6527;
+											atlOffset=4.6051178;
+										};
+										class Item12
+										{
+											dataType="Marker";
+											position[]={9203.3145,136.9389,15825.144};
+											name="marker_62";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=186.30418;
+											id=6528;
+											atlOffset=15.953026;
+										};
+										class Item13
+										{
+											dataType="Marker";
+											position[]={9208.7217,127.11915,15830.834};
+											name="marker_63";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=186.30418;
+											id=6529;
+											atlOffset=5.95504;
+										};
+										class Item14
+										{
+											dataType="Marker";
+											position[]={9207.3203,128.0459,15818.428};
+											name="marker_64";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=186.30418;
+											id=6530;
+											atlOffset=7.1202393;
+										};
+										class Item15
+										{
+											dataType="Marker";
+											position[]={9218.2588,136.62326,15823.397};
+											name="marker_65";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=186.30418;
+											id=6531;
+											atlOffset=13.5009;
+										};
+										class Item16
+										{
+											dataType="Marker";
+											position[]={9222.6084,126.80351,15829.197};
+											name="marker_66";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=186.30418;
+											id=6532;
+											atlOffset=5.5818253;
+										};
+										class Item17
+										{
+											dataType="Marker";
+											position[]={9221.9023,127.47413,15822.976};
+											name="marker_67";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=186.30418;
+											id=6533;
+											atlOffset=6.3206558;
+										};
+										class Item18
+										{
+											dataType="Marker";
+											position[]={9225.8867,135.44159,15825.679};
+											name="marker_68";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=186.30418;
+											id=6534;
+											atlOffset=14.221611;
+										};
+										class Item19
+										{
+											dataType="Marker";
+											position[]={9224.957,126.94581,15816.483};
+											name="marker_69";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=186.30418;
+											id=6535;
+											atlOffset=5.6360016;
+										};
+										class Item20
+										{
+											dataType="Marker";
+											position[]={9213.5869,128.99609,15817.722};
+											name="marker_70";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=186.30418;
+											id=6536;
+											atlOffset=4.2013168;
+										};
+										class Item21
+										{
+											dataType="Marker";
+											position[]={9217.5234,125.92578,15836.005};
+											name="marker_71";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=248.04686;
+											id=6537;
+											atlOffset=4.6039429;
+										};
+										class Item22
+										{
+											dataType="Marker";
+											position[]={9237.5361,127.38721,15832.86};
+											name="marker_72";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=66.451088;
+											id=6538;
+											atlOffset=6.1207809;
+										};
+										class Item23
+										{
+											dataType="Marker";
+											position[]={9235.8906,127.51709,15825.207};
+											name="marker_73";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=157.22179;
+											id=6539;
+											atlOffset=5.1057205;
+										};
+										class Item24
+										{
+											dataType="Marker";
+											position[]={9219.4951,129.49951,15843.524};
+											name="marker_74";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=157.22179;
+											id=6540;
+											atlOffset=8.0091019;
+										};
+										class Item25
+										{
+											dataType="Marker";
+											position[]={9217.5186,144.13124,15836.012};
+											name="marker_49";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=248.04686;
+											id=6502;
+											atlOffset=22.809265;
+										};
+									};
+									id=6541;
+									atlOffset=14.951698;
+								};
+								class Item1
+								{
+									dataType="Layer";
+									name="Kavala_a";
+									class Entities
+									{
+										items=26;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={3378.9697,24.121964,12578.25};
+											name="marker_130";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=38.171349;
+											id=6595;
+											atlOffset=20.028439;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={3357.032,6.0522156,12561.737};
+											name="marker_131";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=177.45517;
+											id=6596;
+											atlOffset=1.5260196;
+										};
+										class Item2
+										{
+											dataType="Marker";
+											position[]={3381.1458,24.251846,12570.731};
+											name="marker_132";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=128.94203;
+											id=6597;
+											atlOffset=20.072586;
+										};
+										class Item3
+										{
+											dataType="Marker";
+											position[]={3358.0286,26.234268,12579.099};
+											name="marker_133";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=128.94203;
+											id=6598;
+											atlOffset=22.114378;
+										};
+										class Item4
+										{
+											dataType="Marker";
+											position[]={3357.5549,6.9789734,12549.266};
+											name="marker_134";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=177.45517;
+											id=6599;
+											atlOffset=2.0651498;
+										};
+										class Item5
+										{
+											dataType="Marker";
+											position[]={3367.5991,15.556335,12555.86};
+											name="marker_135";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=177.45517;
+											id=6600;
+											atlOffset=10.837316;
+										};
+										class Item6
+										{
+											dataType="Marker";
+											position[]={3371.0125,5.7365799,12562.258};
+											name="marker_136";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=177.45517;
+											id=6601;
+											atlOffset=1.2772555;
+										};
+										class Item7
+										{
+											dataType="Marker";
+											position[]={3371.2732,6.407196,12555.996};
+											name="marker_137";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=177.45517;
+											id=6602;
+											atlOffset=1.566267;
+										};
+										class Item8
+										{
+											dataType="Marker";
+											position[]={3374.782,14.374664,12559.283};
+											name="marker_138";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=177.45517;
+											id=6603;
+											atlOffset=9.6953602;
+										};
+										class Item9
+										{
+											dataType="Marker";
+											position[]={3375.2849,5.8788757,12550.057};
+											name="marker_139";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=177.45517;
+											id=6604;
+											atlOffset=-2.0663457;
+										};
+										class Item10
+										{
+											dataType="Marker";
+											position[]={3363.8528,7.9291687,12549.535};
+											name="marker_140";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=177.45517;
+											id=6605;
+											atlOffset=2.510438;
+										};
+										class Item11
+										{
+											dataType="Marker";
+											position[]={3352.4805,15.468201,12555.264};
+											name="marker_141";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=177.45517;
+											id=6606;
+											atlOffset=10.832539;
+										};
+										class Item12
+										{
+											dataType="Marker";
+											position[]={3356.9485,5.6484451,12561.718};
+											name="marker_142";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=177.45517;
+											id=6607;
+											atlOffset=1.1215434;
+										};
+										class Item13
+										{
+											dataType="Marker";
+											position[]={3357.4722,6.5751953,12549.246};
+											name="marker_143";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=177.45517;
+											id=6608;
+											atlOffset=1.6617846;
+										};
+										class Item14
+										{
+											dataType="Marker";
+											position[]={3367.5168,15.152557,12555.838};
+											name="marker_144";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=177.45517;
+											id=6609;
+											atlOffset=10.435515;
+										};
+										class Item15
+										{
+											dataType="Marker";
+											position[]={3370.9224,5.3328094,12562.242};
+											name="marker_145";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=177.45517;
+											id=6610;
+											atlOffset=0.87204123;
+										};
+										class Item16
+										{
+											dataType="Marker";
+											position[]={3371.1819,6.0034256,12555.984};
+											name="marker_146";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=177.45517;
+											id=6611;
+											atlOffset=1.1651864;
+										};
+										class Item17
+										{
+											dataType="Marker";
+											position[]={3374.7024,13.970886,12559.266};
+											name="marker_147";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=177.45517;
+											id=6612;
+											atlOffset=9.2900248;
+										};
+										class Item18
+										{
+											dataType="Marker";
+											position[]={3375.1985,5.4751053,12550.037};
+											name="marker_148";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=177.45517;
+											id=6613;
+											atlOffset=-2.4463658;
+										};
+										class Item19
+										{
+											dataType="Marker";
+											position[]={3363.7722,7.5253906,12549.504};
+											name="marker_149";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=177.45517;
+											id=6614;
+											atlOffset=2.1157098;
+										};
+										class Item20
+										{
+											dataType="Marker";
+											position[]={3359.8621,4.4550781,12571.534};
+											name="marker_150";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=219.7695;
+											id=6615;
+											atlOffset=0.085353851;
+										};
+										class Item21
+										{
+											dataType="Marker";
+											position[]={3378.9768,5.9165039,12578.246};
+											name="marker_151";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=38.171349;
+											id=6616;
+											atlOffset=1.8229785;
+										};
+										class Item22
+										{
+											dataType="Marker";
+											position[]={3381.1548,6.0463867,12570.727};
+											name="marker_152";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=128.94203;
+											id=6617;
+											atlOffset=1.8671117;
+										};
+										class Item23
+										{
+											dataType="Marker";
+											position[]={3358.0352,8.0288086,12579.093};
+											name="marker_153";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=128.94203;
+											id=6618;
+											atlOffset=3.9082346;
+										};
+										class Item24
+										{
+											dataType="Marker";
+											position[]={3359.8547,22.660538,12571.541};
+											name="marker_154";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=219.7695;
+											id=6619;
+											atlOffset=18.290901;
+										};
+										class Item25
+										{
+											dataType="Marker";
+											position[]={3352.5659,15.871964,12555.292};
+											name="marker_129";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=177.45517;
+											id=6594;
+											atlOffset=11.2363;
+										};
+									};
+									id=6646;
+									atlOffset=10.876249;
+								};
+								class Item2
+								{
+									dataType="Layer";
+									name="kavala_b";
+									class Entities
+									{
+										items=26;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={3802.4541,33.209831,12699.57};
+											name="marker_75";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.25227;
+											id=6542;
+											atlOffset=10.648937;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={3794.2791,41.459831,12708.704};
+											name="marker_76";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=115.38908;
+											id=6543;
+											atlOffset=19.184183;
+										};
+										class Item2
+										{
+											dataType="Marker";
+											position[]={3807.124,23.390083,12705.871};
+											name="marker_77";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.25227;
+											id=6544;
+											atlOffset=1.1860352;
+										};
+										class Item3
+										{
+											dataType="Marker";
+											position[]={3787.4246,41.589714,12704.917};
+											name="marker_78";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=206.16083;
+											id=6545;
+											atlOffset=19.368746;
+										};
+										class Item4
+										{
+											dataType="Marker";
+											position[]={3789.9446,43.572136,12727.528};
+											name="marker_79";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=206.16083;
+											id=6546;
+											atlOffset=21.284882;
+										};
+										class Item5
+										{
+											dataType="Marker";
+											position[]={3807.2527,24.316841,12693.39};
+											name="marker_80";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.25227;
+											id=6547;
+											atlOffset=1.5741196;
+										};
+										class Item6
+										{
+											dataType="Marker";
+											position[]={3817.4998,32.894203,12699.674};
+											name="marker_81";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.25227;
+											id=6548;
+											atlOffset=10.889414;
+										};
+										class Item7
+										{
+											dataType="Marker";
+											position[]={3821.1072,23.074448,12705.951};
+											name="marker_82";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=179.25227;
+											id=6549;
+											atlOffset=1.0392876;
+										};
+										class Item8
+										{
+											dataType="Marker";
+											position[]={3821.176,23.745064,12699.688};
+											name="marker_83";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=179.25227;
+											id=6550;
+											atlOffset=1.7204323;
+										};
+										class Item9
+										{
+											dataType="Marker";
+											position[]={3824.7861,31.712532,12702.862};
+											name="marker_84";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=179.25227;
+											id=6551;
+											atlOffset=9.7689095;
+										};
+										class Item10
+										{
+											dataType="Marker";
+											position[]={3825.0002,23.216743,12693.628};
+											name="marker_85";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.25227;
+											id=6552;
+											atlOffset=1.1138172;
+										};
+										class Item11
+										{
+											dataType="Marker";
+											position[]={3813.5557,25.267036,12693.462};
+											name="marker_86";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.25227;
+											id=6553;
+											atlOffset=2.9486561;
+										};
+										class Item12
+										{
+											dataType="Marker";
+											position[]={3802.3743,32.806068,12699.536};
+											name="marker_87";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.25227;
+											id=6554;
+											atlOffset=10.241032;
+										};
+										class Item13
+										{
+											dataType="Marker";
+											position[]={3807.0344,22.986313,12705.858};
+											name="marker_88";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.25227;
+											id=6555;
+											atlOffset=0.78103256;
+										};
+										class Item14
+										{
+											dataType="Marker";
+											position[]={3807.167,23.913063,12693.374};
+											name="marker_89";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.25227;
+											id=6556;
+											atlOffset=1.164114;
+										};
+										class Item15
+										{
+											dataType="Marker";
+											position[]={3817.4128,32.490425,12699.65};
+											name="marker_90";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.25227;
+											id=6557;
+											atlOffset=10.484959;
+										};
+										class Item16
+										{
+											dataType="Marker";
+											position[]={3821.0217,22.670677,12705.941};
+											name="marker_91";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=179.25227;
+											id=6558;
+											atlOffset=0.63380432;
+										};
+										class Item17
+										{
+											dataType="Marker";
+											position[]={3821.082,23.341293,12699.677};
+											name="marker_92";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=179.25227;
+											id=6559;
+											atlOffset=1.3173542;
+										};
+										class Item18
+										{
+											dataType="Marker";
+											position[]={3824.7,31.308754,12702.852};
+											name="marker_93";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=179.25227;
+											id=6560;
+											atlOffset=9.3629208;
+										};
+										class Item19
+										{
+											dataType="Marker";
+											position[]={3824.9097,22.812973,12693.611};
+											name="marker_94";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.25227;
+											id=6561;
+											atlOffset=0.71013451;
+										};
+										class Item20
+										{
+											dataType="Marker";
+											position[]={3813.4768,24.863258,12693.444};
+											name="marker_95";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.25227;
+											id=6562;
+											atlOffset=2.5376244;
+										};
+										class Item21
+										{
+											dataType="Marker";
+											position[]={3782.9736,21.792946,12724.063};
+											name="marker_96";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=296.98914;
+											id=6563;
+											atlOffset=-0.30785751;
+										};
+										class Item22
+										{
+											dataType="Marker";
+											position[]={3794.2747,23.254372,12708.694};
+											name="marker_97";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=115.38908;
+											id=6564;
+											atlOffset=0.97815704;
+										};
+										class Item23
+										{
+											dataType="Marker";
+											position[]={3787.4243,23.384254,12704.908};
+											name="marker_98";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=206.16083;
+											id=6565;
+											atlOffset=1.1629524;
+										};
+										class Item24
+										{
+											dataType="Marker";
+											position[]={3789.9409,25.366676,12727.521};
+											name="marker_99";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=206.16083;
+											id=6566;
+											atlOffset=3.0795059;
+										};
+										class Item25
+										{
+											dataType="Marker";
+											position[]={3782.9771,39.998405,12724.074};
+											name="marker_100";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=296.98914;
+											id=6567;
+											atlOffset=17.897522;
+										};
+									};
+									id=6648;
+									atlOffset=9.9233437;
+								};
+								class Item3
+								{
+									dataType="Layer";
+									name="kavala_c";
+									class Entities
+									{
+										items=26;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={4288.627,49.769714,13922.129};
+											name="marker_102";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=60.817116;
+											id=6569;
+											atlOffset=20.492199;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={4260.2388,31.699965,13917.285};
+											name="marker_103";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=180.67381;
+											id=6570;
+											atlOffset=3.8963966;
+										};
+										class Item2
+										{
+											dataType="Marker";
+											position[]={4287.7427,49.899597,13914.352};
+											name="marker_104";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=151.58856;
+											id=6571;
+											atlOffset=20.77874;
+										};
+										class Item3
+										{
+											dataType="Marker";
+											position[]={4269.626,51.882019,13930.97};
+											name="marker_105";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=151.58856;
+											id=6572;
+											atlOffset=23.284567;
+										};
+										class Item4
+										{
+											dataType="Marker";
+											position[]={4260.064,32.626724,13904.81};
+											name="marker_106";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=180.67381;
+											id=6573;
+											atlOffset=4.994236;
+										};
+										class Item5
+										{
+											dataType="Marker";
+											position[]={4270.4614,41.204086,13910.826};
+											name="marker_107";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=180.67381;
+											id=6574;
+											atlOffset=12.930149;
+										};
+										class Item6
+										{
+											dataType="Marker";
+											position[]={4274.2217,31.384329,13917.024};
+											name="marker_108";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=180.67381;
+											id=6575;
+											atlOffset=2.8284225;
+										};
+										class Item7
+										{
+											dataType="Marker";
+											position[]={4274.1401,32.054947,13910.762};
+											name="marker_109";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=180.67381;
+											id=6576;
+											atlOffset=3.5905037;
+										};
+										class Item8
+										{
+											dataType="Marker";
+											position[]={4277.8232,40.022415,13913.838};
+											name="marker_110";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=180.67381;
+											id=6577;
+											atlOffset=11.344786;
+										};
+										class Item9
+										{
+											dataType="Marker";
+											position[]={4277.8101,31.526625,13904.605};
+											name="marker_111";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=180.67381;
+											id=6578;
+											atlOffset=2.963953;
+										};
+										class Item10
+										{
+											dataType="Marker";
+											position[]={4266.3652,33.57692,13904.726};
+											name="marker_112";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=180.67381;
+											id=6579;
+											atlOffset=5.5929985;
+										};
+										class Item11
+										{
+											dataType="Marker";
+											position[]={4255.335,41.115952,13911.085};
+											name="marker_114";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=180.67381;
+											id=6580;
+											atlOffset=13.655485;
+										};
+										class Item12
+										{
+											dataType="Marker";
+											position[]={4260.1558,31.296194,13917.285};
+											name="marker_115";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=180.67381;
+											id=6581;
+											atlOffset=3.4972668;
+										};
+										class Item13
+										{
+											dataType="Marker";
+											position[]={4259.9746,32.222946,13904.793};
+											name="marker_117";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=180.67381;
+											id=6582;
+											atlOffset=4.595047;
+										};
+										class Item14
+										{
+											dataType="Marker";
+											position[]={4270.377,40.800308,13910.819};
+											name="marker_118";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=180.67381;
+											id=6583;
+											atlOffset=12.530863;
+										};
+										class Item15
+										{
+											dataType="Marker";
+											position[]={4274.1333,30.980558,13917.012};
+											name="marker_119";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=180.67381;
+											id=6584;
+											atlOffset=2.4294338;
+										};
+										class Item16
+										{
+											dataType="Marker";
+											position[]={4274.0454,31.651175,13910.75};
+											name="marker_120";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=180.67381;
+											id=6585;
+											atlOffset=3.1917992;
+										};
+										class Item17
+										{
+											dataType="Marker";
+											position[]={4277.7471,39.618637,13913.834};
+											name="marker_121";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=180.67381;
+											id=6586;
+											atlOffset=10.944506;
+										};
+										class Item18
+										{
+											dataType="Marker";
+											position[]={4277.7222,31.122854,13904.593};
+											name="marker_122";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=180.67381;
+											id=6587;
+											atlOffset=2.5643196;
+										};
+										class Item19
+										{
+											dataType="Marker";
+											position[]={4266.29,33.173141,13904.704};
+											name="marker_123";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=180.67381;
+											id=6588;
+											atlOffset=5.1936474;
+										};
+										class Item20
+										{
+											dataType="Marker";
+											position[]={4268.4082,30.102827,13923.294};
+											name="marker_124";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=242.41472;
+											id=6589;
+											atlOffset=1.7397022;
+										};
+										class Item21
+										{
+											dataType="Marker";
+											position[]={4288.6328,31.564253,13922.126};
+											name="marker_125";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=60.817116;
+											id=6590;
+											atlOffset=2.28652;
+										};
+										class Item22
+										{
+											dataType="Marker";
+											position[]={4287.7515,31.694136,13914.346};
+											name="marker_126";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=151.58856;
+											id=6591;
+											atlOffset=2.5729885;
+										};
+										class Item23
+										{
+											dataType="Marker";
+											position[]={4269.6323,33.676559,13930.964};
+											name="marker_127";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=151.58856;
+											id=6592;
+											atlOffset=5.0789623;
+										};
+										class Item24
+										{
+											dataType="Marker";
+											position[]={4268.4033,48.308289,13923.296};
+											name="marker_128";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=242.41472;
+											id=6593;
+											atlOffset=19.945364;
+										};
+										class Item25
+										{
+											dataType="Marker";
+											position[]={4255.4248,41.519714,13911.107};
+											name="marker_101";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=180.67381;
+											id=6568;
+											atlOffset=14.054308;
+										};
+									};
+									id=6649;
+									atlOffset=12.994442;
+								};
+								class Item4
+								{
+									dataType="Layer";
+									name="kavala_bruecke";
+									class Entities
+									{
+										items=26;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={3690.2402,30.872986,13306.829};
+											name="marker_156";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=34.946953;
+											id=6621;
+											atlOffset=19.685127;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={3669.8818,12.803238,13288.694};
+											name="marker_157";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.64427;
+											id=6622;
+											atlOffset=1.7528744;
+										};
+										class Item2
+										{
+											dataType="Marker";
+											position[]={3692.8364,31.002869,13299.445};
+											name="marker_158";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=125.71773;
+											id=6623;
+											atlOffset=19.214939;
+										};
+										class Item3
+										{
+											dataType="Marker";
+											position[]={3669.2869,32.985291,13306.493};
+											name="marker_159";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=125.71773;
+											id=6624;
+											atlOffset=23.554745;
+										};
+										class Item4
+										{
+											dataType="Marker";
+											position[]={3669.9272,13.729996,13276.21};
+											name="marker_160";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.64427;
+											id=6625;
+											atlOffset=2.5797787;
+										};
+										class Item5
+										{
+											dataType="Marker";
+											position[]={3680.2136,22.307358,13282.415};
+											name="marker_161";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.64427;
+											id=6626;
+											atlOffset=10.558743;
+										};
+										class Item6
+										{
+											dataType="Marker";
+											position[]={3683.8428,12.487602,13288.658};
+											name="marker_162";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=179.22749;
+											id=6627;
+											atlOffset=5.444211;
+										};
+										class Item7
+										{
+											dataType="Marker";
+											position[]={3683.8933,13.158218,13282.415};
+											name="marker_163";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=179.64427;
+											id=6628;
+											atlOffset=5.3207579;
+										};
+										class Item8
+										{
+											dataType="Marker";
+											position[]={3687.5249,21.125687,13285.559};
+											name="marker_164";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=179.64427;
+											id=6629;
+											atlOffset=13.463591;
+										};
+										class Item9
+										{
+											dataType="Marker";
+											position[]={3687.6753,12.629898,13276.324};
+											name="marker_165";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.64427;
+											id=6630;
+											atlOffset=0.88786507;
+										};
+										class Item10
+										{
+											dataType="Marker";
+											position[]={3676.2297,14.680191,13276.238};
+											name="marker_166";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.64427;
+											id=6631;
+											atlOffset=3.5069475;
+										};
+										class Item11
+										{
+											dataType="Marker";
+											position[]={3665.0874,22.219223,13282.403};
+											name="marker_167";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.64427;
+											id=6632;
+											atlOffset=11.182169;
+										};
+										class Item12
+										{
+											dataType="Marker";
+											position[]={3669.7964,12.399467,13288.678};
+											name="marker_168";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.64427;
+											id=6633;
+											atlOffset=1.3500099;
+										};
+										class Item13
+										{
+											dataType="Marker";
+											position[]={3669.8447,13.326218,13276.198};
+											name="marker_169";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=3.6101282;
+											b=1.0841908;
+											angle=179.64427;
+											id=6634;
+											atlOffset=2.176836;
+										};
+										class Item14
+										{
+											dataType="Marker";
+											position[]={3680.1318,21.90358,13282.396};
+											name="marker_170";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.64427;
+											id=6635;
+											atlOffset=10.154902;
+										};
+										class Item15
+										{
+											dataType="Marker";
+											position[]={3683.7788,12.083832,13288.663};
+											name="marker_171";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5505676;
+											b=1.0841908;
+											angle=179.64427;
+											id=6636;
+											atlOffset=5.0448327;
+										};
+										class Item16
+										{
+											dataType="Marker";
+											position[]={3683.8015,12.754448,13282.4};
+											name="marker_172";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=2.5510671;
+											b=1.0841908;
+											angle=179.64427;
+											id=6637;
+											atlOffset=4.9161615;
+										};
+										class Item17
+										{
+											dataType="Marker";
+											position[]={3687.4434,20.721909,13285.546};
+											name="marker_173";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=4.2525439;
+											angle=179.64427;
+											id=6638;
+											atlOffset=13.066668;
+										};
+										class Item18
+										{
+											dataType="Marker";
+											position[]={3687.5869,12.226128,13276.31};
+											name="marker_174";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.64427;
+											id=6639;
+											atlOffset=0.48582649;
+										};
+										class Item19
+										{
+											dataType="Marker";
+											position[]={3676.1499,14.276413,13276.219};
+											name="marker_175";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=1.2786131;
+											angle=179.64427;
+											id=6640;
+											atlOffset=3.1041183;
+										};
+										class Item20
+										{
+											dataType="Marker";
+											position[]={3671.5422,11.2061,13299.052};
+											name="marker_176";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=216.54419;
+											id=6641;
+											atlOffset=0.20854282;
+										};
+										class Item21
+										{
+											dataType="Marker";
+											position[]={3690.2478,12.667526,13306.829};
+											name="marker_177";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.2424536;
+											angle=34.946953;
+											id=6642;
+											atlOffset=1.479804;
+										};
+										class Item22
+										{
+											dataType="Marker";
+											position[]={3692.8442,12.797409,13299.443};
+											name="marker_178";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.813806;
+											angle=125.71766;
+											id=6643;
+											atlOffset=1.0099382;
+										};
+										class Item23
+										{
+											dataType="Marker";
+											position[]={3669.2949,14.779831,13306.49};
+											name="marker_179";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=10.802588;
+											angle=125.71766;
+											id=6644;
+											atlOffset=5.3477716;
+										};
+										class Item24
+										{
+											dataType="Marker";
+											position[]={3671.5344,29.41156,13299.054};
+											name="marker_180";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.2207031;
+											b=3.5594401;
+											angle=216.54419;
+											id=6645;
+											atlOffset=18.41411;
+										};
+										class Item25
+										{
+											dataType="Marker";
+											position[]={3665.1726,22.622986,13282.421};
+											name="marker_155";
+											markerType="RECTANGLE";
+											type="rectangle";
+											colorName="ColorBlack";
+											a=1.1265168;
+											b=7.3044853;
+											angle=179.64427;
+											id=6620;
+											atlOffset=11.585022;
+										};
+									};
+									id=6650;
+									atlOffset=11.07666;
+								};
+							};
+							id=6501;
+							atlOffset=-10.844765;
+						};
+						class Item2
+						{
+							dataType="Layer";
+							name="tonos bucht";
+							class Entities
+							{
+								items=10;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12349.89,21.643684,22834.561};
+									};
+									side="Empty";
+									class Attributes
+									{
+									};
+									id=6869;
+									type="Land_TreeBin_F";
+									atlOffset=0.28699875;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12369.505,24.399586,22835.488};
+										angles[]={0,1.6947205,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6868;
+									type="Land_i_House_Small_03_V1_F";
+									atlOffset=0.77219009;
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12363.565,24.261728,22853.609};
+										angles[]={6.1887999,0,0.11285178};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6871;
+									type="Land_W_sharpStone_02";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12354.136,25.071177,22816.729};
+										angles[]={0.1973958,4.4352474,0.094385199};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6872;
+									type="Land_W_sharpStone_02";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12332.167,23.461916,22857.326};
+										angles[]={0,1.7391534,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6864;
+									type="Land_i_House_Small_01_V2_F";
+									atlOffset=1.0692959;
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12330.946,25.424219,22824.883};
+										angles[]={0,1.6715096,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6866;
+									type="Land_i_House_Big_01_V1_F";
+									atlOffset=0.81702232;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12322.165,23.02775,22846.287};
+										angles[]={0,4.8521881,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6863;
+									type="Land_i_House_Small_02_V2_F";
+									atlOffset=2.0452709;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={8421.3574,112.86955,25113.723};
+										angles[]={0,4.4505897,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										init="call{[this, 8] call ace_cargo_fnc_setSize;[this, true, [0, 3, 1], 0] call ace_dragging_fnc_setCarryable;[this, true, [0, 2, 0], 0] call ace_dragging_fnc_setDraggable;}";
+									};
+									id=5226;
+									type="OPT_B_Slingload_01_Medevac_F";
+									atlOffset=-0.0011138916;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="ammoBox";
+											expression="[_this,_value] call bis_fnc_initAmmoBox;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[[[[""launch_NLAW_F"",""arifle_MX_F"",""arifle_MX_SW_F""],[2,4,2]],[[""30Rnd_65x39_caseless_mag"",""16Rnd_9x21_Mag"",""30Rnd_45ACP_Mag_SMG_01"",""20Rnd_762x51_Mag"",""100Rnd_65x39_caseless_mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_green"",""Laserbatteries"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[48,12,12,12,12,12,4,4,12,4,12,12,4,4,4,4]],[[""Laserdesignator"",""FirstAidKit"",""acc_flashlight""],[2,20,4]],[[""B_Kitbag_mcamo""],[4]]],false]";
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12348.256,23.46644,22850.539};
+										angles[]={0,3.2057159,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6867;
+									type="Land_Water_source_F";
+									atlOffset=0.20499992;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12319.839,22.570627,22828.984};
+										angles[]={0,1.7137166,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6865;
+									type="Land_i_Addon_03_V1_F";
+									atlOffset=1.2533436;
+								};
+							};
+							id=6873;
+							atlOffset=43.453331;
+						};
+						class Item3
+						{
+							dataType="Layer";
+							name="lager_panagiotis";
+							class Entities
+							{
+								items=12;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5947.2793,104.69408,12437.962};
+										angles[]={0,6.2127428,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6657;
+									type="Land_cmp_Shed_F";
+									atlOffset=-7.6293945e-006;
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5924.3906,109.27191,12494.567};
+										angles[]={0,3.2075005,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6656;
+									type="Land_cmp_Hopper_F";
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5907.334,108.1751,12492.244};
+										angles[]={0,1.3614205,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6651;
+									type="Land_Factory_Conv1_End_F";
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5951.8252,102.2153,12462.428};
+										angles[]={0,1.6103455,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6652;
+									type="Land_Factory_Conv1_Main_F";
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5905.8198,112.95565,12471.91};
+										angles[]={0,1.6136001,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6653;
+									type="Land_Factory_Conv2_F";
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5897.1587,104.11758,12422.534};
+										angles[]={0,4.8162336,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6654;
+									type="Land_Factory_Tunnel_F";
+									atlOffset=-1.6699371;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={6010.4648,104.62508,12531.652};
+										angles[]={0,3.9705629,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6658;
+									type="Land_Shed_Small_F";
+									atlOffset=0.30789948;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={6006.627,105.30154,12556.023};
+										angles[]={0,0.82519674,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6659;
+									type="Land_u_Shed_Ind_F";
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5955.5864,103.58009,12446.035};
+										angles[]={0,4.7864604,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=6655;
+									type="Land_dp_transformer_F";
+									atlOffset=0.48847961;
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5995.0337,106.78358,12570.65};
+										angles[]={0,0.82879293,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+									};
+									id=6660;
+									type="Land_Tank_rust_F";
+									atlOffset=0.39135742;
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5934.8726,103.35493,12462.645};
+										angles[]={0,0.096429422,6.1926446};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6661;
+									type="Land_Rampart_F";
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={5962.1191,102.64935,12463.552};
+										angles[]={6.1933894,1.5326017,6.2244101};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=6666;
+									type="Land_Rampart_F";
+									atlOffset=-0.66568756;
+								};
+							};
+							id=6874;
+							atlOffset=-0.78556061;
+						};
+						class Item4
+						{
+							dataType="Layer";
+							name="Stravos_Radar";
+							class Entities
+							{
+								items=58;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13271.478,13.938877,14945.837};
+										angles[]={0.02666023,0.7763927,6.2591896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6913;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13262.983,13.673573,14949.801};
+										angles[]={6.2631893,0.77592683,0.0093350215};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6914;
+									type="Land_BagBunker_Large_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13247.585,14.484449,14960.291};
+										angles[]={0.022517746,0.77647585,6.2656059};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6915;
+									type="Land_PortableLight_double_F";
+									atlOffset=0.03509903;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13293.679,13.33141,14967.585};
+										angles[]={6.2671871,2.33777,0.0026520467};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6916;
+									type="Land_ToiletBox_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13252.927,14.069008,14977.447};
+										angles[]={0,0.74075198,6.223258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6917;
+									type="Land_WaterTank_F";
+									atlOffset=-0.0014982224;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13275.436,13.843041,14950.343};
+										angles[]={0.026657995,0.72405487,6.2711902};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6918;
+									type="Land_Cargo20_military_green_F";
+									atlOffset=-0.00075721741;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13279.176,13.947638,14942.756};
+										angles[]={0.02666023,0.037001349,0.0026520467};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6919;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13286.894,13.759113,14945.877};
+										angles[]={0.074528553,5.5220985,6.2645216};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6920;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13248.94,14.203609,14957.224};
+										angles[]={6.2631893,0.77392048,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6921;
+									type="Land_HBarrier_5_F";
+									atlOffset=0.21201992;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13244.979,14.339728,14961.088};
+										angles[]={6.2631893,0.7748217,6.2259154};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6922;
+									type="Land_HBarrier_5_F";
+									atlOffset=0.096241951;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13252.905,13.789037,14958.294};
+										angles[]={6.2805109,5.5079989,6.2578578};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6923;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13244.602,14.799724,14966.286};
+										angles[]={6.2738566,5.5141668,6.2219291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6924;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item12
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13246.682,14.753996,14973.665};
+										angles[]={6.2605205,4.5571771,6.200706};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6925;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item13
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13249.342,14.750798,14981.381};
+										angles[]={6.2711902,5.5184879,6.2565274};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6926;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.2397766e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item14
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13247.639,14.390983,14988.126};
+										angles[]={6.276526,5.4956331,6.2565274};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6927;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item15
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13255.351,14.477706,14979.896};
+										angles[]={6.2711902,0.77566791,6.223258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6928;
+									type="Land_HBarrierBig_F";
+									atlOffset=9.5367432e-007;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item16
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13244.142,14.518304,14981.69};
+										angles[]={0.0093286335,3.9690306,6.2285743};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6929;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.2397766e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item17
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13251.678,14.093378,14992.054};
+										angles[]={0.027993103,5.5260043,6.2219291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6930;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item18
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13271.698,13.599583,14997.267};
+										angles[]={0.0093350215,3.8781843,6.2365522};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6931;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item19
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13280.31,13.073873,14993.664};
+										angles[]={0.0093286335,3.8767121,6.2671909};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6932;
+									type="Land_BagBunker_Large_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item20
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13295.884,13.125463,14983.648};
+										angles[]={0.022517746,3.8807993,6.2656059};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6933;
+									type="Land_PortableLight_double_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item21
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13263.839,13.950721,15000.033};
+										angles[]={6.2791886,3.1404977,6.2338929};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6934;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item22
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13256.801,14.277688,14996.912};
+										angles[]={6.272521,2.341655,6.2299027};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6935;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item23
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13294.628,12.728952,14986.864};
+										angles[]={0.0066682254,3.8810074,0.0066682254};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6936;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item24
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13298.704,12.789,14983.144};
+										angles[]={0.023993526,3.8798497,6.2698579};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6937;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item25
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13290.625,12.71058,14985.616};
+										angles[]={0.0066682254,2.3313127,0.0066682254};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6938;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item26
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13299.318,13.374089,14977.985};
+										angles[]={0.023993526,2.3358624,6.2698579};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6939;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item27
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13297.378,13.371618,14970.392};
+										angles[]={6.2778587,1.3804898,0.0039967569};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6940;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item28
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13295.092,13.230526,14962.631};
+										angles[]={6.2605233,2.3374422,0.0093350215};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6941;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item29
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13295.829,12.973138,14955.039};
+										angles[]={0.046633169,2.3447692,6.2685208};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6942;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item30
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13289.002,13.226095,14963.828};
+										angles[]={6.2605233,3.8798966,6.2671871};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6943;
+									type="Land_HBarrierBig_F";
+									atlOffset=1.0490417e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item31
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13300.104,12.786428,14962.217};
+										angles[]={6.2671871,0.78974956,0.0039967569};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6944;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item32
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13291.795,13.117884,14951.063};
+										angles[]={0.0066592805,2.3467073,0.017329043};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6945;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item33
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13264.04,14.092533,14978.626};
+										angles[]={6.2805333,3.9144447,6.2352223};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6946;
+									type="Land_Cargo20_military_green_F";
+									atlOffset=-0.0023670197;
+								};
+								class Item34
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13277.619,13.759568,14952.469};
+										angles[]={0.031988446,0.76488054,6.2658563};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6947;
+									type="Land_Cargo20_military_green_F";
+									atlOffset=-0.0011692047;
+								};
+								class Item35
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13264.988,13.311241,14957.526};
+										angles[]={6.2778587,5.5091777,6.2325621};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6948;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item36
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13267.36,13.216072,14962.217};
+										angles[]={6.2778587,4.6750546,6.2325621};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6949;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item37
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13278.437,12.864078,14986.072};
+										angles[]={6.253861,5.4753051,0.0093286335};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6950;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item38
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13275.874,12.904499,14981.355};
+										angles[]={0.033321146,4.7552695,6.2631865};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6951;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item39
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13260.47,13.668526,14974.84};
+										angles[]={0,0.77804494,6.2152901};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6952;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item40
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13283.658,12.952535,14968.657};
+										angles[]={6.2658529,0.77117753,6.2618537};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6953;
+									type="Land_HBarrier_5_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item41
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13292.207,13.289716,14965.973};
+										angles[]={6.2605233,2.33777,0.0093350215};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6954;
+									type="Land_ToiletBox_F";
+									atlOffset=-4.6730042e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item42
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13250.646,14.046703,14975.154};
+										angles[]={6.2259145,0.74084234,6.2352209};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6955;
+									type="Land_WaterTank_F";
+									atlOffset=-0.0046110153;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item43
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13261.063,13.454638,14972.317};
+										angles[]={0,4.0709476,6.2152901};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6956;
+									type="Land_WaterBarrel_F";
+									atlOffset=-0.0010185242;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item44
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13263.793,13.845334,14997.997};
+										angles[]={0.022514746,6.2576337,6.2656102};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6957;
+									type="Land_PortableLight_double_F";
+									atlOffset=9.5367432e-007;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item45
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13248.911,14.37214,14969.023};
+										angles[]={0.022517746,4.9761343,6.2656059};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6958;
+									type="Land_PortableLight_double_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item46
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13280.012,13.63959,14954.945};
+										angles[]={0.031988446,0.77834183,6.2658563};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6959;
+									type="Land_Cargo20_military_green_F";
+									atlOffset=-0.00043392181;
+								};
+								class Item47
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13294.31,16.993658,14981.253};
+										angles[]={0.022517746,3.8822124,6.2656059};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6960;
+									type="Land_Cargo_Patrol_V1_F";
+									atlOffset=1.0490417e-005;
+								};
+								class Item48
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13249.415,18.165573,14962.647};
+										angles[]={0.022517746,0.76394325,6.2656059};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=6961;
+									type="Land_Cargo_Patrol_V1_F";
+									atlOffset=1.0490417e-005;
+								};
+								class Item49
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13288.145,12.444601,14968.084};
+										angles[]={6.2605233,0.67344373,6.2671871};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6962;
+									type="Land_Pallets_F";
+									atlOffset=1.0490417e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item50
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13253.343,14.08427,14984.82};
+										angles[]={6.2805109,5.5552959,6.213963};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6963;
+									type="Land_PaperBox_closed_F";
+									atlOffset=1.0490417e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item51
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13260.413,13.35496,14971.428};
+										angles[]={0,5.9520741,6.2152901};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6964;
+									type="Land_MetalBarrel_F";
+									atlOffset=-0.00053119659;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item52
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13259.281,13.408174,14971.918};
+										angles[]={0,0.77634537,6.223258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6965;
+									type="Land_BarrelEmpty_grey_F";
+									atlOffset=-0.00040245056;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item53
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13259.685,13.383948,14971.291};
+										angles[]={0,0.88294822,6.223258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6966;
+									type="Land_BarrelTrash_grey_F";
+									atlOffset=-0.00040245056;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item54
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13256.001,13.870162,14986.079};
+										angles[]={0.027993103,2.9676058,6.2139621};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6967;
+									type="Land_PaperBox_closed_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item55
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13256.556,13.560113,14988.171};
+										angles[]={0.027993103,0.7750355,6.2139621};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=6968;
+									type="Land_Pallets_stack_F";
+									atlOffset=-0.00053405762;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item56
+								{
+									dataType="Logic";
+									class PositionInfo
+									{
+										position[]={13272.619,12.279107,14973.49};
+										angles[]={6.2525272,2.3687866,6.2445378};
+									};
+									areaSize[]={32.37075,0,33.591248};
+									areaIsRectangle=1;
+									flags=1;
+									id=6970;
+									type="ModuleHideTerrainObjects_F";
+									atlOffset=1.1444092e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="#filter";
+											expression="_this setVariable [""#filter"",_value]";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=15;
+												};
+											};
+										};
+										class Attribute1
+										{
+											property="#hideLocally";
+											expression="_this setVariable [""#hideLocally"",_value]";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=2;
+									};
+								};
+								class Item57
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13274.505,28.126377,14907.527};
+										angles[]={0,1.2316614,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6875;
+									type="Land_Radar_F";
+									atlOffset=9.5367432e-007;
+								};
+							};
+							id=6969;
+							atlOffset=0.77899456;
+						};
+						class Item5
+						{
+							dataType="Layer";
+							name="Checkpoint Ivestonia";
+							class Entities
+							{
+								items=146;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13046.389,33.979557,19447.729};
+										angles[]={0,4.6085134,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7113;
+									type="Land_d_Windmill01_F";
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13061.928,32.182919,19439.512};
+										angles[]={0,3.4554648,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7114;
+									type="Land_d_House_Small_02_V1_F";
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13052.985,32.926609,19452.529};
+										angles[]={6.2060056,1.7194217,0.021328852};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7115;
+									type="Land_Wreck_Truck_dropside_F";
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13057.362,32.606857,19451.467};
+										angles[]={6.2060056,5.2471218,0.021328852};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7116;
+									type="Land_Wreck_Car2_F";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13055.691,31.571484,19448.656};
+										angles[]={6.2219291,3.3117893,0.0053265258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7117;
+									type="Land_Garbage_line_F";
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13050.453,30.618584,19439.477};
+										angles[]={6.2179451,3.2932017,6.2631865};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7118;
+									type="Land_Pipes_large_F";
+									atlOffset=0.0017776489;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13047.415,31.137981,19440.322};
+										angles[]={6.1914434,5.00951,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7119;
+									type="Land_Pallets_stack_F";
+									atlOffset=-0.00037193298;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13045.944,30.797276,19441.197};
+										angles[]={6.1914434,1.4064589,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7120;
+									type="Land_WoodenBox_F";
+									atlOffset=8.7738037e-005;
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13047.149,31.292204,19441.979};
+										angles[]={6.1914434,6.2235894,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7121;
+									type="Land_Pallets_stack_F";
+									atlOffset=-0.00020599365;
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13047.355,32.125965,19453.154};
+										angles[]={6.2219291,3.1939561,0.011995304};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7122;
+									type="Land_Sacks_heap_F";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13046.972,32.03635,19451.77};
+										angles[]={6.2219291,5.0047102,0.011995304};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7123;
+									type="Land_Sacks_heap_F";
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13049.755,32.162735,19453.285};
+										angles[]={6.2219291,4.9048643,0.011995304};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7124;
+									type="Land_Sacks_heap_F";
+								};
+								class Item12
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13048.642,32.143986,19453.197};
+										angles[]={6.2219291,1.4635509,0.011995304};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7125;
+									type="Land_Sacks_heap_F";
+								};
+								class Item13
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13059.555,32.402206,19449.467};
+										angles[]={6.2060056,3.3988638,0.014664836};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7126;
+									type="Land_CratesShabby_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item14
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13057.889,32.060261,19445.24};
+										angles[]={6.2033563,0.35393697,0.0039967569};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7127;
+									type="Land_CratesWooden_F";
+									atlOffset=0.040466309;
+								};
+								class Item15
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13039.163,32.121632,19448.045};
+										angles[]={6.2378845,3.3081126,6.2778587};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7128;
+									type="Land_WoodenCart_F";
+									atlOffset=-0.000415802;
+								};
+								class Item16
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13058.793,32.114563,19446.119};
+										angles[]={6.2033563,1.88846,0.0039967569};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7129;
+									type="Land_CratesShabby_F";
+								};
+								class Item17
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13048.83,31.491646,19440.695};
+										angles[]={6.1914434,1.7422694,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7130;
+									type="Land_CratesShabby_F";
+								};
+								class Item18
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13053.357,31.485512,19442.75};
+										angles[]={6.1821971,3.4652915,0.02666023};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7131;
+									type="Land_WoodenTable_large_F";
+									atlOffset=0.022558212;
+								};
+								class Item19
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13039.086,31.681639,19446.115};
+										angles[]={6.1914434,4.4247427,6.2778478};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7132;
+									type="Land_Sacks_heap_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item20
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13054.654,31.734301,19445.818};
+										angles[]={6.2033553,3.4570072,0.0053377044};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+									};
+									id=7133;
+									type="MetalBarrel_burning_F";
+									atlOffset=-2.4795532e-005;
+								};
+								class Item21
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13026.151,32.461128,19420.49};
+										angles[]={6.2545013,5.1754651,6.2256861};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=7090;
+									type="Land_BagBunker_Tower_F";
+								};
+								class Item22
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13014.037,32.823353,19447.969};
+										angles[]={6.2605233,2.1910458,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7139;
+									type="RoadBarrier_small_F";
+									atlOffset=-6.8664551e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item23
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13012.75,32.922371,19450.592};
+										angles[]={6.2605233,6.2341733,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7140;
+									type="RoadBarrier_small_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item24
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13011.104,32.920967,19447.957};
+										angles[]={6.2325621,1.102863,6.256525};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7141;
+									type="RoadBarrier_small_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item25
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13016.676,31.465065,19430.906};
+										angles[]={6.2551923,0.67477304,6.2405448};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6984;
+									type="Land_CncBarrier_stripes_F";
+									atlOffset=0.14220047;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item26
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13007.008,32.521679,19441.467};
+										angles[]={6.2645183,5.8395839,6.1980581};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=6985;
+									type="Land_CncBarrier_stripes_F";
+								};
+								class Item27
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13009.646,32.291027,19441.17};
+										angles[]={6.2645183,0.89315981,6.1980581};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6986;
+									type="Land_CncBarrier_stripes_F";
+									atlOffset=7.8201294e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item28
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13005.514,33.892178,19467.92};
+										angles[]={6.253859,3.8330522,6.200707};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7002;
+									type="Land_CncBarrier_stripes_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item29
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13022.361,32.721912,19461.289};
+										angles[]={6.2325621,1.1656576,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=7006;
+									type="Land_CncBarrier_stripes_F";
+								};
+								class Item30
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13021.089,32.682499,19458.652};
+										angles[]={6.2525291,2.3652837,6.2325621};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7007;
+									type="Land_CncBarrier_stripes_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item31
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13011.488,32.704006,19449.4};
+										angles[]={6.2605257,5.1400356,6.2285743};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=7135;
+									type="Land_CncBarrier_stripes_F";
+								};
+								class Item32
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13012.615,32.604183,19447.59};
+										angles[]={6.2605233,0.075815283,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=7136;
+									type="Land_CncBarrier_stripes_F";
+								};
+								class Item33
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13013.765,32.612942,19449.531};
+										angles[]={6.2605233,1.0747339,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=7137;
+									type="Land_CncBarrier_stripes_F";
+								};
+								class Item34
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13019.245,31.968864,19434.494};
+										angles[]={6.2166171,5.3762307,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6987;
+									type="Land_BagBunker_Small_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item35
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13002.871,34.570694,19464.396};
+										angles[]={6.2192731,2.2524199,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7003;
+									type="Land_BagBunker_Small_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item36
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13010.321,32.442383,19435.025};
+										angles[]={6.2192721,2.3440328,6.1980586};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=6971;
+									type="Land_Wreck_Offroad_F";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item37
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13015.758,31.602343,19432.42};
+										angles[]={6.2551923,2.1019509,6.2405448};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6972;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.16928673;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item38
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13011.631,32.055065,19438.854};
+										angles[]={6.2192721,0.73182911,6.1980586};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6973;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item39
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13021.019,31.737574,19440.01};
+										angles[]={6.1967349,2.1755266,6.2658529};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6974;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item40
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13017.68,31.589731,19435.645};
+										angles[]={6.2166171,2.1322062,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6975;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.032932281;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item41
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13016.791,31.579016,19434.193};
+										angles[]={6.2192721,2.1074946,6.2405448};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6976;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.079458237;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item42
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13016.336,31.592762,19433.457};
+										angles[]={6.2192721,5.3006158,6.2405448};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6977;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.12090111;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item43
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13017.672,31.577135,19435.48};
+										angles[]={6.2166171,2.1540668,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6978;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.031030655;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item44
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13019.795,31.65979,19438.459};
+										angles[]={6.2166171,2.226413,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6979;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item45
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13012.686,31.910652,19437.879};
+										angles[]={6.2192721,0.58509737,6.2405448};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6980;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item46
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13006.418,33.801109,19466.391};
+										angles[]={6.253859,5.2613378,6.200707};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6995;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item47
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13001.222,33.694363,19458.988};
+										angles[]={6.2046804,5.3377218,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6996;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item48
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13004.42,33.872147,19463.211};
+										angles[]={6.253861,5.2915931,6.2046809};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6997;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.0013809204;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item49
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13005.34,33.914146,19464.631};
+										angles[]={6.253859,5.2668819,6.200707};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6998;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.075496674;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item50
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13005.81,33.968708,19465.355};
+										angles[]={6.253859,2.1768086,6.200707};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6999;
+									type="Land_BagFence_Short_F";
+									atlOffset=0.14761353;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item51
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13004.424,33.875099,19463.369};
+										angles[]={6.253861,5.3134542,6.2046809};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7000;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item52
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13002.24,33.764805,19460.453};
+										angles[]={6.2046804,5.388607,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7001;
+									type="Land_BagFence_Short_F";
+									atlOffset=3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item53
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13018.166,32.798241,19457.303};
+										angles[]={6.2525291,2.8939891,6.2432079};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7004;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item54
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13029.166,32.288643,19448.912};
+										angles[]={6.259192,1.1679522,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6981;
+									type="Land_Wreck_T72_hull_F";
+									atlOffset=1.9073486e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item55
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12995.615,33.650074,19451.93};
+										angles[]={6.2073312,2.2144957,6.253861};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6983;
+									type="Land_Wreck_T72_hull_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item56
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13004.229,33.124649,19440.762};
+										angles[]={6.259192,1.7915168,6.2605233};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6988;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0022583008;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item57
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12999.722,33.103783,19437.85};
+										angles[]={6.2338929,1.7852412,6.2605233};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6989;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.001625061;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item58
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12996.318,33.19577,19435.709};
+										angles[]={6.2551923,2.0009956,6.2365522};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6990;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0011825562;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item59
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12993.572,33.329906,19435.307};
+										angles[]={6.2698488,2.0015111,6.2219291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6991;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00072860718;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item60
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12990.914,33.483932,19434.604};
+										angles[]={6.2698488,1.789014,6.2219291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6992;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00033569336;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item61
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12987.596,33.678261,19432.842};
+										angles[]={0.0080009829,1.7860434,6.213963};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6993;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.0017280579;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item62
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13024.538,33.213703,19463.814};
+										angles[]={6.2285728,4.8153596,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7008;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0013389587;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item63
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13028.183,33.182026,19465.578};
+										angles[]={6.2352238,4.8083544,6.2578578};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7009;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00037002563;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item64
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13031.28,33.210548,19468.07};
+										angles[]={6.2418756,5.025156,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7010;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00056838989;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item65
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13034.016,33.153088,19468.785};
+										angles[]={6.2418756,5.0251851,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7011;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item66
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13036.551,33.143032,19469.771};
+										angles[]={6.2618566,4.8130035,6.2685208};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7012;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00031661987;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item67
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13039.653,33.194645,19471.902};
+										angles[]={6.2352223,4.8100233,6.2685208};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7013;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00019454956;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item68
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12983.693,33.916199,19431.1};
+										angles[]={6.2711854,1.7915168,6.1940885};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7014;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.0056381226;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item69
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12979.912,34.091633,19429.779};
+										angles[]={6.2711854,1.7852412,6.247201};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7015;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00016021729;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item70
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12976.509,34.164852,19427.639};
+										angles[]={6.2645216,2.0009956,6.253861};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7016;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0013313293;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item71
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12973.763,34.22337,19427.236};
+										angles[]={6.2645216,2.0015111,6.2658563};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7017;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00078201294;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item72
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12971.104,34.259521,19426.533};
+										angles[]={6.2658563,1.789014,6.2645216};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7018;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00072479248;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item73
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12967.786,34.277142,19424.771};
+										angles[]={6.1821971,1.7860434,6.2645216};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7019;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.00044631958;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item74
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12967.322,34.04842,19420.875};
+										angles[]={6.2219281,0.83196527,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7020;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0019721985;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item75
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12966.202,33.824566,19417.064};
+										angles[]={6.1611295,0.82723463,6.2591896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7021;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00036621094;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item76
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12966.017,33.334167,19413.039};
+										angles[]={6.1611295,1.0421902,6.2591896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7022;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0015335083;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item77
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12964.713,32.984295,19410.586};
+										angles[]={6.1232305,1.043552,0.0146689};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7023;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00077819824;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item78
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12963.758,32.695827,19408.014};
+										angles[]={6.196734,0.77251762,0.0146689};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7024;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0010643005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item79
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12963.252,32.45578,19404.326};
+										angles[]={6.2352209,0.82957816,6.2591896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7025;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0057315826;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item80
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13036.263,29.641165,19402.857};
+										angles[]={6.1729674,3.8953555,0.0066682254};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7026;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.13694;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item81
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13037.076,30.082569,19406.805};
+										angles[]={6.1729674,3.8905966,0.0066682254};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7027;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.003610611;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item82
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13037.022,30.423012,19410.822};
+										angles[]={6.2179451,4.10359,6.2578578};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7028;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0021648407;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item83
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13038.051,30.561905,19413.326};
+										angles[]={6.2179451,4.1040859,6.2578578};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7029;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00085449219;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item84
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13038.796,30.70048,19415.963};
+										angles[]={6.2245855,3.891113,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7030;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00043869019;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item85
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13038.88,30.828236,19419.676};
+										angles[]={6.2631893,3.8857594,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7031;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0023822784;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item86
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13035.782,30.97736,19422.104};
+										angles[]={6.2631893,2.9339876,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7032;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00095939636;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item87
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13033.085,31.069469,19424.936};
+										angles[]={6.247201,2.9272451,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7033;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0028972626;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item88
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13029.743,31.173956,19427.252};
+										angles[]={6.247201,3.1505768,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7034;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0034179688;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item89
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13028.291,31.269197,19429.627};
+										angles[]={6.247201,3.1519318,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7035;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0033512115;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item90
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13026.502,31.384207,19431.613};
+										angles[]={6.247201,2.8725352,6.247201};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7036;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.001543045;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item91
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13023.56,31.620226,19433.938};
+										angles[]={6.2166171,2.9295986,6.247201};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7037;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00052261353;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item92
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13064.77,32.760216,19451.502};
+										angles[]={6.187479,2.6939058,0.033321146};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7038;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0014019012;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item93
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13061.384,32.850864,19453.615};
+										angles[]={6.187479,2.6873426,0.033321146};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7039;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00075149536;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item94
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13057.579,32.850227,19454.945};
+										angles[]={6.2312322,2.9031146,0.033322938};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7040;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0011253357;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item95
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13055.551,32.896324,19456.828};
+										angles[]={6.2352223,2.9039361,0.021328852};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7041;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0017204285;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item96
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13053.341,32.929543,19458.486};
+										angles[]={6.2352223,2.6910551,0.021328852};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7042;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0009803772;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item97
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13049.896,32.927891,19459.986};
+										angles[]={6.2352209,2.6881294,0.019999012};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7043;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0012550354;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item98
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13046.533,32.766205,19457.938};
+										angles[]={6.2432065,1.7339919,0.012000273};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7044;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0011863708;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item99
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13042.865,32.659893,19456.438};
+										angles[]={6.2432065,1.7292192,0.012000273};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7045;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0034942627;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item100
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13039.565,32.547634,19454.082};
+										angles[]={6.2312322,1.9441695,0.0013372133};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7046;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0026416779;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item101
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13036.813,32.519882,19453.6};
+										angles[]={6.2312322,1.9456416,0.0013372133};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7047;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0015888214;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item102
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13034.162,32.498848,19452.758};
+										angles[]={6.2378831,1.6744214,6.2725158};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7048;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-5.7220459e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item103
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13030.958,32.460629,19450.863};
+										angles[]={6.259192,1.73142,6.2511969};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7049;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00080108643;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item104
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13040.401,33.284824,19474.873};
+										angles[]={6.2498641,3.8756309,6.253861};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7050;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0006942749;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item105
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13041.102,33.422203,19478.828};
+										angles[]={6.2312322,3.8690722,6.253859};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7051;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-4.9591064e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item106
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13040.896,33.616791,19482.838};
+										angles[]={6.2365522,4.0846481,6.2485313};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7052;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=2.2888184e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item107
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13041.876,33.705074,19485.432};
+										angles[]={6.2338929,4.0856228,6.2485328};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7053;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-5.7220459e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item108
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13042.577,33.814049,19488.102};
+										angles[]={6.233892,3.8727529,0.0013372133};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7054;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00078201294;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item109
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13042.667,33.998993,19491.848};
+										angles[]={6.233892,3.8698275,0.0013372133};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7055;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00077819824;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item110
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12999.321,34.453953,19462.516};
+										angles[]={6.2192731,1.3003149,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7056;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-1.9073486e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item111
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12998.367,34.380432,19460.957};
+										angles[]={6.2139621,1.3012538,6.2299018};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7057;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00023269653;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item112
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13022.943,32.006218,19438.869};
+										angles[]={6.1980586,1.2568314,6.2658529};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7058;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-1.9073486e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item113
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13021.906,31.902361,19437.273};
+										angles[]={6.2166171,1.2573463,6.247201};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7059;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00032424927;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item114
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12996.252,33.508911,19447.91};
+										angles[]={6.2086568,1.7915168,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7060;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0034332275;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item115
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12992.471,33.573406,19446.59};
+										angles[]={6.2591896,1.7852412,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7061;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0002746582;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item116
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12989.067,33.712406,19444.449};
+										angles[]={6.2751846,2.0009956,6.213963};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7062;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00047302246;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item117
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12986.321,33.898922,19444.047};
+										angles[]={6.2751846,2.0015111,6.213963};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7063;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0010986328;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item118
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12983.663,34.013725,19443.344};
+										angles[]={6.253861,1.789014,6.2352223};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7064;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00050354004;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item119
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12980.345,34.104904,19441.582};
+										angles[]={6.256525,1.7860434,6.2405448};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7065;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00094604492;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item120
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12976.442,34.230583,19439.84};
+										angles[]={0.0080009829,1.7915168,6.2405462};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7066;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0005569458;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item121
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12972.661,34.364666,19438.52};
+										angles[]={0.0013372133,1.7852412,6.2525291};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7067;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-9.1552734e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item122
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12969.258,34.446926,19436.379};
+										angles[]={6.2711854,2.0009956,6.2658563};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7068;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-1.5258789e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item123
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12966.512,34.502975,19435.977};
+										angles[]={6.2711854,2.0015111,6.2525272};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7069;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00016784668;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item124
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12963.854,34.545338,19435.273};
+										angles[]={6.2352238,1.789014,0.0053265258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7070;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-8.392334e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item125
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12960.535,34.443138,19433.512};
+										angles[]={6.2352238,1.7860434,0.0053265258};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7071;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=4.9591064e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item126
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13031.255,32.114456,19443.066};
+										angles[]={6.2206001,5.6908994,6.256525};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7072;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00019836426;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item127
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13035.697,31.802521,19440.143};
+										angles[]={6.2259154,5.6846237,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7073;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00050163269;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item128
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13039.695,31.600536,19439.385};
+										angles[]={6.2299027,5.9003782,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7074;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0013523102;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item129
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13041.96,31.425133,19437.791};
+										angles[]={6.2299027,5.9008937,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7075;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0011940002;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item130
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13044.473,31.291988,19436.518};
+										angles[]={6.2299027,5.6883965,6.2645216};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7076;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0074653625;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item131
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13047.823,31.174326,19435.293};
+										angles[]={6.2179451,5.6854262,6.2765174};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7077;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0051994324;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item132
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12957.806,34.500835,19433.791};
+										angles[]={6.2285743,2.2941284,6.2645249};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7078;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0028076172;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item133
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12953.852,34.607052,19434.463};
+										angles[]={6.2285743,2.2878528,6.2645249};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7079;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0071372986;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item134
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12949.82,34.849266,19434.262};
+										angles[]={6.1782393,2.5036073,6.2352223};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7080;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0011405945;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item135
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12947.22,35.076294,19435.232};
+										angles[]={6.1782393,2.5041227,6.2352223};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7081;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0011405945;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item136
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12944.54,35.27636,19435.881};
+										angles[]={6.1782398,2.2916255,6.2312331};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7082;
+									type="Land_CzechHedgehog_01_new_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item137
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={12940.783,35.455795,19435.936};
+										angles[]={6.1453981,2.288655,6.2645216};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7083;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.0018730164;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item138
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13050.309,31.064798,19433.76};
+										angles[]={6.2179451,5.6908994,6.2631865};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7084;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.0060691833;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item139
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13054.003,30.876787,19432.104};
+										angles[]={6.2192721,5.6846237,6.2631865};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7085;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00044059753;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item140
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13058.001,30.752337,19431.346};
+										angles[]={6.2192731,5.9003782,6.2711854};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7086;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00032234192;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item141
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13060.266,30.622753,19429.752};
+										angles[]={6.2232571,5.9008937,6.2671871};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7087;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00038719177;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item142
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13062.778,30.506191,19428.479};
+										angles[]={6.2232571,5.6883965,6.2671871};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7088;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.00039863586;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item143
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13066.129,30.367464,19427.254};
+										angles[]={6.223258,5.6854262,6.253859};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7089;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=0.0027980804;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item144
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13012.337,33.066563,19448.711};
+										angles[]={6.2605257,1.2568314,6.2285743};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=7138;
+									type="Land_CzechHedgehog_01_new_F";
+									atlOffset=-0.0018310547;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item145
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={13012.99,33.86068,19460.781};
+										angles[]={6.2325621,5.1848536,6.2631893};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=6982;
+									type="Land_Wreck_Ural_F";
+								};
+							};
+							id=7134;
+							atlOffset=-0.020362854;
+						};
+						class Item6
+						{
+							dataType="Layer";
+							name="ekali_stones";
+							class Entities
+							{
+								items=44;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.99,52.559052,10596.993};
+										angles[]={5.9165478,0.49517944,0.069223277};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7205;
+									type="Land_BagFence_Round_F";
+									atlOffset=0.055473328;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17806.42,54.445511,10609.088};
+										angles[]={6.2060056,5.067771,0.063913256};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7206;
+									type="Land_Campfire_F";
+									atlOffset=-3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17805.662,54.993393,10614.395};
+										angles[]={0.019996032,6.1156034,0.073202357};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7207;
+									type="Land_TentA_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17802.303,54.700096,10613.038};
+										angles[]={0.063912325,5.605916,0.091741994};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7208;
+									type="Land_TentA_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17809.873,54.402508,10605.137};
+										angles[]={6.2060056,4.6140003,0.063913256};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7209;
+									type="Land_WoodPile_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17808.322,54.624416,10609.219};
+										angles[]={6.196734,5.9466262,0.073202357};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7210;
+									type="Land_WoodenLog_F";
+									atlOffset=6.8664551e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17809.557,54.215473,10605.99};
+										angles[]={6.2060056,2.6516421,0.063913256};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7211;
+									type="Land_Axe_F";
+									atlOffset=-0.00010299683;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17791.172,52.466301,10598.413};
+										angles[]={0,5.0427914,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7212;
+									type="Land_Shovel_F";
+									atlOffset=0.070808411;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17810.602,54.530704,10606.006};
+										angles[]={6.2060056,5.2311745,0.063913256};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7213;
+									type="Land_CanisterFuel_F";
+									atlOffset=-0.00058364868;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17789.752,52.762653,10602.211};
+										angles[]={6.1927657,4.0587492,0.091741346};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7214;
+									type="Land_Canteen_F";
+									atlOffset=0.016933441;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.033,52.838303,10603.011};
+										angles[]={6.1927657,0.39600444,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7215;
+									type="Land_GasCooker_F";
+									atlOffset=0.030487061;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.426,52.667767,10600.705};
+										angles[]={6.1927657,4.2765112,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7216;
+									type="Land_RiceBox_F";
+									atlOffset=0.041469574;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item12
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.268,52.62534,10600.449};
+										angles[]={6.1927657,5.2926683,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7217;
+									type="Land_RiceBox_F";
+									atlOffset=0.033119202;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item13
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17807.906,54.457844,10609.55};
+										angles[]={6.2060056,2.4562025,0.063913256};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7218;
+									type="Land_TinContainer_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item14
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17789.535,52.752293,10599.326};
+										angles[]={6.1927657,4.3715105,0.091741346};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7219;
+									type="Land_BagFence_Long_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item15
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17788.563,52.912197,10602.078};
+										angles[]={6.1927657,4.3669624,0.091741346};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7220;
+									type="Land_BagFence_Long_F";
+									atlOffset=3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item16
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17809.477,55.274612,10614.318};
+										angles[]={0.019996032,0.3824608,0.073202357};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7221;
+									type="Land_TentA_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item17
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17808.484,54.495537,10609.274};
+										angles[]={6.196734,5.9303598,0.073202357};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7222;
+									type="Land_Camping_Light_F";
+									atlOffset=8.0108643e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item18
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17788.369,53.124691,10604.617};
+										angles[]={6.1927657,2.0174472,0.091741346};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7223;
+									type="Land_BagFence_Round_F";
+									atlOffset=3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item19
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17791.662,52.485512,10597.955};
+										angles[]={0,6.150013,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7224;
+									type="Land_DuctTape_F";
+									atlOffset=0.093769073;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item20
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17785.484,52.936024,10614.119};
+										angles[]={6.2325635,4.6900549,0.1495418};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7225;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item21
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17820.57,56.681973,10616.816};
+										angles[]={6.1167397,1.3167259,6.2525272};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7226;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item22
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17811.031,55.165695,10613.451};
+										angles[]={0.019996032,1.1430537,0.073202357};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7227;
+									type="Land_Basket_F";
+									atlOffset=-0.0031051636;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item23
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17810.783,55.178219,10614.454};
+										angles[]={0.017284269,4.9197478,0.075970724};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7228;
+									type="Land_Sack_F";
+									atlOffset=-3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item24
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17789.16,53.04937,10603.246};
+										angles[]={6.1927657,4.7959151,0.091741346};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7229;
+									type="Land_Sacks_heap_F";
+									atlOffset=0.0046920776;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item25
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.998,52.697315,10597.602};
+										angles[]={6.1927657,2.3840992,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7230;
+									type="Land_CanisterPlastic_F";
+									atlOffset=0.05878067;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item26
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17791.984,52.752693,10597.418};
+										angles[]={5.9165478,1.5511186,0.069223277};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7231;
+									type="Land_CanisterPlastic_F";
+									atlOffset=0.075580597;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item27
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17809.795,54.877636,10612.674};
+										angles[]={0.023803961,4.8982897,0.07329765};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7232;
+									type="Land_Canteen_F";
+									atlOffset=-0.0013198853;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item28
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17820.885,56.398689,10615.188};
+										angles[]={6.1167397,1.3996693,6.2525272};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7233;
+									type="Land_BagFence_Short_F";
+									atlOffset=-0.00015640259;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item29
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17805.039,53.995159,10607.232};
+										angles[]={6.2060056,0.67446643,0.063913256};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7234;
+									type="Land_WoodenBox_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item30
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.189,52.770805,10601.423};
+										angles[]={6.1927657,6.0087509,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7235;
+									type="Land_CerealsBox_F";
+									atlOffset=0.032264709;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item31
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.145,52.747425,10601.226};
+										angles[]={6.1927657,5.585568,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7236;
+									type="Land_CerealsBox_F";
+									atlOffset=0.029781342;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item32
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.205,52.677624,10600.71};
+										angles[]={6.1927657,5.6905408,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7237;
+									type="Land_BottlePlastic_V2_F";
+									atlOffset=0.030452728;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item33
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17790.504,52.621925,10600.51};
+										angles[]={6.1927657,5.0630021,0.069222413};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										createAsSimpleObject=1;
+										disableSimulation=1;
+									};
+									id=7238;
+									type="Land_BakedBeans_F";
+									atlOffset=0.044578552;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item34
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17823.707,54.54723,10598.891};
+										angles[]={6.1887999,4.3372469,6.2551923};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7239;
+									type="Land_BagFence_Round_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item35
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17821.135,55.574078,10608.341};
+										angles[]={6.183517,5.2968793,0.0093350215};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7240;
+									type="Land_BagFence_Round_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item36
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17821.082,56.104286,10613.471};
+										angles[]={6.1167397,1.3996693,6.2525272};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7242;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item37
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17821.318,55.891064,10611.787};
+										angles[]={6.2232571,1.3996693,6.2525272};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7243;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item38
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17821.545,55.752045,10610.133};
+										angles[]={6.183517,1.3996693,0.0093350215};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7244;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item39
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17785.488,52.852997,10612.44};
+										angles[]={6.2525272,4.6900549,0.14954139};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7245;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item40
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17785.635,52.824871,10610.804};
+										angles[]={6.2525272,4.4883451,0.14954139};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7246;
+									type="Land_BagFence_Short_F";
+									atlOffset=3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item41
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17785.998,52.830723,10609.214};
+										angles[]={6.2525272,4.4883451,0.14954139};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7247;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item42
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17785.646,53.107353,10617.476};
+										angles[]={6.2698536,4.7972679,0.11285178};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7248;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item43
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={17785.52,53.029305,10615.852};
+										angles[]={6.2325635,4.7977533,0.1495418};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.2;
+										disableSimulation=1;
+									};
+									id=7249;
+									type="Land_BagFence_Short_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+							};
+							id=7241;
+							atlOffset=-0.067783356;
+						};
+						class Item7
+						{
+							dataType="Layer";
+							name="chekpoint agios";
+							class Entities
+							{
+								items=24;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={9226.1846,121.67102,15830.794};
+										angles[]={6.2711902,5.8732605,0.013332055};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=6155;
+									type="Land_CncBarrier_stripes_F";
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={9229.9746,121.68231,15830.892};
+										angles[]={0,0.92505932,0.0012918708};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6156;
+									type="Land_CncBarrier_stripes_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={9240.8232,122.16606,15842.42};
+										angles[]={0.0039967569,4.3516345,6.2711854};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6157;
+									type="Land_BagBunker_Small_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={9218.1143,122.08092,15823.31};
+										angles[]={6.2765174,1.250838,0.010664274};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=6246;
+									type="Land_BagBunker_Small_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item4
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41687,7 +49363,7 @@ class Mission
 									type="Land_Wreck_Offroad_F";
 									atlOffset=7.6293945e-006;
 								};
-								class Item344
+								class Item5
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41728,7 +49404,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item345
+								class Item6
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41768,7 +49444,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item346
+								class Item7
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41809,7 +49485,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item347
+								class Item8
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41850,7 +49526,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item348
+								class Item9
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41891,7 +49567,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item349
+								class Item10
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41932,7 +49608,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item350
+								class Item11
 								{
 									dataType="Object";
 									class PositionInfo
@@ -41973,7 +49649,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item351
+								class Item12
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42014,7 +49690,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item352
+								class Item13
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42054,7 +49730,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item353
+								class Item14
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42094,23 +49770,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item354
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={9258.8184,122.17731,15841.094};
-										angles[]={0.0039967569,5.9692402,6.2711854};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-									};
-									id=6152;
-									type="Land_Wreck_Ural_F";
-								};
-								class Item355
+								class Item15
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42150,144 +49810,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item356
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={9242.5488,121.58164,15838.361};
-										angles[]={0.0039967569,5.935451,6.2711854};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=6154;
-									type="Land_CncBarrier_stripes_F";
-									atlOffset=2.2888184e-005;
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item357
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={9226.1846,121.67102,15830.794};
-										angles[]={6.2711902,5.8732605,0.013332055};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-									};
-									id=6155;
-									type="Land_CncBarrier_stripes_F";
-								};
-								class Item358
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={9229.9746,121.68231,15830.892};
-										angles[]={0,0.92505932,0.0012918708};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=6156;
-									type="Land_CncBarrier_stripes_F";
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item359
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={9240.8232,122.16606,15842.42};
-										angles[]={0.0039967569,4.3516345,6.2711854};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=6157;
-									type="Land_BagBunker_Small_F";
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="allowDamage";
-											expression="_this allowdamage _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"BOOL"
-														};
-													};
-													value=0;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
-								class Item360
+								class Item16
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42328,7 +49851,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item361
+								class Item17
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42369,7 +49892,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item362
+								class Item18
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42410,7 +49933,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item363
+								class Item19
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42451,7 +49974,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item364
+								class Item20
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42492,7 +50015,7 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item365
+								class Item21
 								{
 									dataType="Object";
 									class PositionInfo
@@ -42533,25 +50056,29 @@ class Mission
 										nAttributes=1;
 									};
 								};
-								class Item366
-								{
-									dataType="Marker";
-									position[]={9231.3428,121.312,15835.857};
-									name="marker_35";
-									text="Ceckpoint  Agios Dionisos";
-									type="loc_DangerousForces";
-									colorName="ColorWEST";
-									angle=69.070984;
-									id=6244;
-									atlOffset=-0.00034332275;
-								};
-								class Item367
+								class Item22
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={9218.1143,122.08092,15823.31};
-										angles[]={6.2765174,1.250838,0.010664274};
+										position[]={9258.8184,122.17731,15841.094};
+										angles[]={0.0039967569,5.9692402,6.2711854};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=6152;
+									type="Land_Wreck_Ural_F";
+								};
+								class Item23
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={9242.5488,121.58164,15838.361};
+										angles[]={0.0039967569,5.935451,6.2711854};
 									};
 									side="Empty";
 									flags=4;
@@ -42559,8 +50086,9 @@ class Mission
 									{
 										disableSimulation=1;
 									};
-									id=6246;
-									type="Land_BagBunker_Small_F";
+									id=6154;
+									type="Land_CncBarrier_stripes_F";
+									atlOffset=2.2888184e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -42586,21 +50114,89 @@ class Mission
 									};
 								};
 							};
-							id=5471;
-							atlOffset=-0.073486328;
+							id=7250;
+							atlOffset=0.010650635;
 						};
 					};
 					id=3010;
-					atlOffset=-0.073486328;
+					atlOffset=63.322952;
 				};
-				class Item6
+				class Item4
 				{
 					dataType="Layer";
 					name="zeugsanflaggen";
+					class Entities
+					{
+						items=4;
+						class Item0
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={5937.8911,101.45818,12432.094};
+								angles[]={6.2033563,3.7187345,0.0039967569};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=6662;
+							type="Land_Bulldozer_01_wreck_F";
+						};
+						class Item1
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={5957.4995,104.69886,12456.152};
+								angles[]={6.276526,5.4253283,0.11548356};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=6663;
+							type="Land_Excavator_01_wreck_F";
+						};
+						class Item2
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={5978.6304,116.78239,12595.434};
+								angles[]={0.069222413,4.5892029,6.1980586};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=6664;
+							type="Land_MiningShovel_01_abandoned_F";
+						};
+						class Item3
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={5870.0278,142.57121,12613.556};
+								angles[]={0.30121395,0,6.0064712};
+							};
+							side="Empty";
+							class Attributes
+							{
+							};
+							id=6665;
+							type="Land_Wreck_Ural_F";
+							atlOffset=14.674927;
+						};
+					};
 					id=3025;
-					atlOffset=185.97;
+					atlOffset=13.277908;
 				};
-				class Item7
+				class Item5
 				{
 					dataType="Layer";
 					name="zeus_nato";
@@ -43457,7 +51053,7 @@ class Mission
 					id=3867;
 					atlOffset=185.97;
 				};
-				class Item8
+				class Item6
 				{
 					dataType="Layer";
 					name="zeus_csat";
@@ -44657,13 +52253,13 @@ class Mission
 					id=3877;
 					atlOffset=174.44518;
 				};
-				class Item9
+				class Item7
 				{
 					dataType="Layer";
 					name="nato_carrier";
 					class Entities
 					{
-						items=8;
+						items=11;
 						class Item0
 						{
 							dataType="Layer";
@@ -44674,84 +52270,84 @@ class Mission
 								class Item0
 								{
 									dataType="Marker";
-									position[]={33.984985,-14.380157,17069.186};
+									position[]={24902.795,-14.380112,12997.184};
 									name="marker_14";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=10.244446;
 									b=32.28862;
-									angle=89.832436;
+									angle=182.35748;
 									id=5815;
-									atlOffset=171.58984;
+									atlOffset=171.58989;
 								};
 								class Item1
 								{
 									dataType="Marker";
-									position[]={36.311523,-2.9900818,16885.799};
+									position[]={24719.482,-2.990036,13002.939};
 									name="marker_5";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=49.559002;
 									b=174.3134;
-									angle=179.35478;
+									angle=271.88016;
 									id=5816;
-									atlOffset=182.52382;
+									atlOffset=184.18953;
 								};
 								class Item2
 								{
 									dataType="Marker";
-									position[]={7.2617188,-2.4065857,16963.945};
+									position[]={24798.832,-2.4065399,13028.516};
 									name="marker_6";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=16.405113;
 									b=10.26421;
-									angle=268.53052;
+									angle=1.0557287;
 									id=5817;
-									atlOffset=183.42093;
+									atlOffset=183.577;
 								};
 								class Item3
 								{
 									dataType="Marker";
-									position[]={37.539307,-4.2267151,16647.914};
+									position[]={24481.773,-4.2266693,13012.188};
 									name="marker_8";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=64.534431;
 									b=32.28862;
-									angle=89.832436;
+									angle=182.35748;
 									id=5818;
-									atlOffset=181.74329;
+									atlOffset=187.93765;
 								};
 								class Item4
 								{
 									dataType="Marker";
-									position[]={-158.32092,-2.4007874,16534.402};
+									position[]={24377.002,-2.4007416,13212.863};
 									name="marker_21";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=109.08534;
 									b=19.220396;
-									angle=95.128838;
+									angle=187.65388;
 									id=5819;
-									atlOffset=183.56921;
+									atlOffset=179.35474;
 								};
 								class Item5
 								{
 									dataType="Marker";
-									position[]={-168.51733,-2.4007874,17186.762};
+									position[]={25029.178,-2.4007416,13194.306};
 									name="marker_22";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=114.72881;
 									b=23.83993;
-									angle=92.532669;
+									angle=185.05777;
 									id=5820;
-									atlOffset=183.56921;
+									atlOffset=183.56926;
 								};
 							};
 							id=4164;
-							atlOffset=182.73026;
+							atlOffset=182.94789;
 						};
 						class Item1
 						{
@@ -44765,10 +52361,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-3.0438807,23.796295,16831.541};
-										angles[]={0,6.1776476,0};
+										position[]={24667.012,23.796341,13044.646};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -44776,7 +52373,7 @@ class Mission
 									};
 									id=5823;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.06503;
+									atlOffset=0.00028800964;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -44806,10 +52403,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={1.4558752,23.796295,16832.049};
-										angles[]={0,6.1776476,0};
+										position[]={24667.32,23.796341,13040.128};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -44817,7 +52415,7 @@ class Mission
 									};
 									id=5824;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.06047;
+									atlOffset=0.00030326843;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -44847,8 +52445,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={10.637642,23.796295,16858.346};
-										angles[]={0,3.2709734,0};
+										position[]={24693.189,23.796341,13029.799};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									flags=4;
@@ -44859,7 +52457,7 @@ class Mission
 									};
 									id=5825;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=3.8146973e-006;
+									atlOffset=0.00028038025;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -44889,10 +52487,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={8.3657875,23.796295,16858.645};
-										angles[]={0,3.2709734,0};
+										position[]={24693.584,23.796341,13032.053};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -44900,7 +52499,7 @@ class Mission
 									};
 									id=5826;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.02592;
+									atlOffset=0.00022888184;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -44930,8 +52529,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.1412997,23.796509,16858.906};
-										angles[]={0,3.2709644,0};
+										position[]={24693.947,23.796555,13034.266};
+										angles[]={0,4.8858371,0};
 									};
 									side="Empty";
 									flags=4;
@@ -44942,7 +52541,7 @@ class Mission
 									};
 									id=5827;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0002117157;
+									atlOffset=0.00044250488;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -44972,10 +52571,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={3.7517736,23.796234,16859.199};
-										angles[]={0,3.2709734,0};
+										position[]={24694.344,23.79628,13036.637};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -44983,7 +52583,7 @@ class Mission
 									};
 									id=5828;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.03203;
+									atlOffset=0.00018310547;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45013,8 +52613,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={3.6929357,23.795715,16832.338};
-										angles[]={0,6.1776428,0};
+										position[]={24667.512,23.795761,13037.879};
+										angles[]={0,1.5093255,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45024,7 +52624,7 @@ class Mission
 									};
 									id=5829;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.05353;
+									atlOffset=211.87592;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45054,10 +52654,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={5.9822421,23.796082,16832.568};
-										angles[]={0,6.1776476,0};
+										position[]={24667.641,23.796127,13035.585};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -45065,7 +52666,7 @@ class Mission
 									};
 									id=5830;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.0475;
+									atlOffset=8.9645386e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45095,10 +52696,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={8.1992836,23.796082,16832.854};
-										angles[]={0,6.1776476,0};
+										position[]={24667.828,23.796127,13033.357};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -45106,7 +52708,7 @@ class Mission
 									};
 									id=5831;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.04214;
+									atlOffset=8.9645386e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45136,10 +52738,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={10.512276,23.796082,16833.061};
-										angles[]={0,6.1776476,0};
+										position[]={24667.934,23.796127,13031.038};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -45147,7 +52750,7 @@ class Mission
 									};
 									id=5832;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.03879;
+									atlOffset=9.727478e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45177,10 +52780,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={1.5940588,23.796051,16859.461};
-										angles[]={0,3.2709734,0};
+										position[]={24694.701,23.796097,13038.781};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -45188,7 +52792,6 @@ class Mission
 									};
 									id=5833;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.03473;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45218,10 +52821,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-0.67107797,23.796051,16859.748};
-										angles[]={0,3.2709734,0};
+										position[]={24695.088,23.796097,13041.033};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -45229,7 +52833,6 @@ class Mission
 									};
 									id=5834;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.03719;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45259,8 +52862,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-2.888119,23.796051,16860.014};
-										angles[]={0,3.2709734,0};
+										position[]={24695.451,23.796097,13043.238};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45270,7 +52873,7 @@ class Mission
 									};
 									id=5835;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.03685;
+									atlOffset=210.89958;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45300,8 +52903,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.2859464,23.79599,16860.293};
-										angles[]={0,3.2709734,0};
+										position[]={24695.832,23.796036,13045.622};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45311,7 +52914,7 @@ class Mission
 									};
 									id=5836;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.03679;
+									atlOffset=210.85808;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45341,8 +52944,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-3.5380213,23.785522,16917.422};
-										angles[]={0,6.1776428,0};
+										position[]={24752.834,23.785568,13041.357};
+										angles[]={0,1.5093255,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45352,7 +52955,7 @@ class Mission
 									};
 									id=5837;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.09288;
+									atlOffset=209.62929;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45382,8 +52985,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-1.3386805,23.785797,16917.688};
-										angles[]={0,6.1776476,0};
+										position[]={24753.002,23.785843,13039.149};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45393,7 +52996,7 @@ class Mission
 									};
 									id=5838;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.09351;
+									atlOffset=209.63596;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45423,8 +53026,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={0.73273063,23.786224,16917.848};
-										angles[]={0,6.1776476,0};
+										position[]={24753.066,23.78627,13037.07};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45435,7 +53038,7 @@ class Mission
 									};
 									id=5839;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00016403198;
+									atlOffset=0.00020980835;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45465,8 +53068,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={9.8772621,23.786194,16944.162};
-										angles[]={0,3.2709734,0};
+										position[]={24778.957,23.78624,13026.776};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45477,7 +53080,7 @@ class Mission
 									};
 									id=5840;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0001335144;
+									atlOffset=0.00015068054;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45507,8 +53110,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={7.60712,23.786194,16944.469};
-										angles[]={0,3.2709734,0};
+										position[]={24779.361,23.78624,13029.029};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45519,7 +53122,7 @@ class Mission
 									};
 									id=5841;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0001335144;
+									atlOffset=0.00014877319;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45549,8 +53152,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={5.3876376,23.786194,16944.703};
-										angles[]={0,3.2709734,0};
+										position[]={24779.689,23.78624,13031.233};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45561,7 +53164,7 @@ class Mission
 									};
 									id=5842;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0001335144;
+									atlOffset=0.00014877319;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45591,8 +53194,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={2.9923742,23.786133,16945.008};
-										angles[]={0,3.2709734,0};
+										position[]={24780.102,23.786179,13033.614};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45603,7 +53206,7 @@ class Mission
 									};
 									id=5843;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=7.2479248e-005;
+									atlOffset=8.7738037e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45633,8 +53236,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={2.9401281,23.785919,16918.15};
-										angles[]={0,6.1776428,0};
+										position[]={24753.273,23.785965,13034.856};
+										angles[]={0,1.5093255,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45644,7 +53247,7 @@ class Mission
 									};
 									id=5844;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.08784;
+									atlOffset=209.64906;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45674,8 +53277,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={5.2240634,23.78598,16918.4};
-										angles[]={0,6.1776476,0};
+										position[]={24753.424,23.786026,13032.557};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45685,7 +53288,7 @@ class Mission
 									};
 									id=5845;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.08554;
+									atlOffset=209.65306;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45715,8 +53318,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={7.4722323,23.78598,16918.666};
-										angles[]={0,6.1776476,0};
+										position[]={24753.588,23.786026,13030.302};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45726,7 +53329,7 @@ class Mission
 									};
 									id=5846;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.08325;
+									atlOffset=209.65816;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45756,8 +53359,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={9.7406654,23.78598,16918.873};
-										angles[]={0,6.1776476,0};
+										position[]={24753.695,23.786026,13028.026};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45767,7 +53370,7 @@ class Mission
 									};
 									id=5847;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.0793;
+									atlOffset=209.66553;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45797,8 +53400,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={0.84405875,23.78598,16945.281};
-										angles[]={0,3.2709734,0};
+										position[]={24780.471,23.786026,13035.752};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45808,7 +53411,7 @@ class Mission
 									};
 									id=5848;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.15306;
+									atlOffset=209.3933;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45838,8 +53441,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.2413907,23.785919,16945.807};
-										angles[]={0,3.2709734,0};
+										position[]={24781.264,23.785965,13041.807};
+										angles[]={0,4.8858461,0};
 									};
 									side="Empty";
 									class Attributes
@@ -45849,7 +53452,7 @@ class Mission
 									};
 									id=5849;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.15553;
+									atlOffset=209.3817;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45879,8 +53482,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.878357,23.786346,16993.859};
-										angles[]={0,3.0245638,0};
+										position[]={24825.65,23.786392,12957.652};
+										angles[]={0,4.6394367,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45891,7 +53494,7 @@ class Mission
 									};
 									id=5850;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00032806396;
+									atlOffset=0.0002822876;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45921,8 +53524,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={74.650574,23.786346,16993.566};
-										angles[]={0,3.0245638,0};
+										position[]={24825.461,23.786392,12959.89};
+										angles[]={0,4.6394367,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45933,7 +53536,7 @@ class Mission
 									};
 									id=5851;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00031280518;
+									atlOffset=0.0002822876;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -45963,8 +53566,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={72.347351,23.786346,16993.313};
-										angles[]={0,3.0245638,0};
+										position[]={24825.303,23.786392,12962.2};
+										angles[]={0,4.6394367,0};
 									};
 									side="Empty";
 									flags=4;
@@ -45975,7 +53578,7 @@ class Mission
 									};
 									id=5852;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00031280518;
+									atlOffset=0.0002822876;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46005,8 +53608,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={63.488956,23.786346,16966.896};
-										angles[]={0,0.11792506,0};
+										position[]={24799.303,23.786392,12972.213};
+										angles[]={0,1.7327929,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46017,7 +53620,7 @@ class Mission
 									};
 									id=5853;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00033187866;
+									atlOffset=0.00028610229;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46047,8 +53650,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={65.826111,23.786346,16966.637};
-										angles[]={0,0.11792506,0};
+										position[]={24798.938,23.786392,12969.892};
+										angles[]={0,1.7327929,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46059,7 +53662,7 @@ class Mission
 									};
 									id=5854;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00033187866;
+									atlOffset=0.00028610229;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46089,8 +53692,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={67.993347,23.78653,16966.355};
-										angles[]={0,0.11792452,0};
+										position[]={24798.564,23.786575,12967.739};
+										angles[]={0,1.7327924,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46101,7 +53704,7 @@ class Mission
 									};
 									id=5855;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00051498413;
+									atlOffset=0.00046920776;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46131,8 +53734,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={70.389587,23.786285,16966.133};
-										angles[]={0,0.11792506,0};
+										position[]={24798.236,23.786331,12965.356};
+										angles[]={0,1.7327929,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46143,7 +53746,7 @@ class Mission
 									};
 									id=5856;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00027084351;
+									atlOffset=0.00022506714;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46173,8 +53776,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={70.131287,23.786469,16992.986};
-										angles[]={0,3.0245578,0};
+										position[]={24825.076,23.786514,12964.429};
+										angles[]={0,4.639431,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46185,7 +53788,7 @@ class Mission
 									};
 									id=5857;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00043487549;
+									atlOffset=0.00040435791;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46215,8 +53818,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={67.843689,23.786133,16992.719};
-										angles[]={0,3.0245638,0};
+										position[]={24824.912,23.786179,12966.727};
+										angles[]={0,4.6394367,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46227,7 +53830,7 @@ class Mission
 									};
 									id=5858;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=9.9182129e-005;
+									atlOffset=6.8664551e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46257,8 +53860,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={65.602966,23.786133,16992.439};
-										angles[]={0,3.0245638,0};
+										position[]={24824.73,23.786179,12968.978};
+										angles[]={0,4.6394367,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46269,7 +53872,7 @@ class Mission
 									};
 									id=5859;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=9.9182129e-005;
+									atlOffset=6.8664551e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46299,8 +53902,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={63.357609,23.786133,16992.133};
-										angles[]={0,3.0245638,0};
+										position[]={24824.523,23.786179,12971.234};
+										angles[]={0,4.6394367,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46311,7 +53914,7 @@ class Mission
 									};
 									id=5860;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=9.9182129e-005;
+									atlOffset=6.6757202e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46341,8 +53944,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={72.535339,23.786133,16965.896};
-										angles[]={0,0.11792506,0};
+										position[]={24797.906,23.786179,12963.222};
+										angles[]={0,1.7327929,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46353,7 +53956,7 @@ class Mission
 									};
 									id=5861;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00011825562;
+									atlOffset=7.2479248e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46383,8 +53986,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={77.043152,23.786133,16965.381};
-										angles[]={0,0.11792506,0};
+										position[]={24797.189,23.786179,12958.743};
+										angles[]={0,1.7327929,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46395,7 +53998,7 @@ class Mission
 									};
 									id=5862;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00014877319;
+									atlOffset=7.2479248e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46425,8 +54028,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.9391446,23.78653,16879.197};
-										angles[]={0,0.011321014,0};
+										position[]={24714.705,23.786575,13044.438};
+										angles[]={0,1.6261888,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46437,7 +54040,7 @@ class Mission
 									};
 									id=5863;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00047111511;
+									atlOffset=0.000623703;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46467,8 +54070,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-2.6627772,23.78653,16879.174};
-										angles[]={0,0.011324169,0};
+										position[]={24714.582,23.786575,13042.169};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46479,7 +54082,7 @@ class Mission
 									};
 									id=5864;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00047111511;
+									atlOffset=0.00060844421;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46509,8 +54112,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-0.39739633,23.78653,16879.193};
-										angles[]={0,0.011324169,0};
+										position[]={24714.502,23.786575,13039.904};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46521,7 +54124,7 @@ class Mission
 									};
 									id=5865;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00047111511;
+									atlOffset=0.000623703;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46551,8 +54154,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={1.8862951,23.78653,16879.117};
-										angles[]={0,0.011324169,0};
+										position[]={24714.324,23.786575,13037.627};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46563,7 +54166,7 @@ class Mission
 									};
 									id=5866;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00047111511;
+									atlOffset=0.000623703;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46593,8 +54196,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4.1360507,23.786346,16879.172};
-										angles[]={0,0.011321014,0};
+										position[]={24714.281,23.786392,13035.369};
+										angles[]={0,1.6261888,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46605,7 +54208,7 @@ class Mission
 									};
 									id=5867;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00028800964;
+									atlOffset=0.00044059753;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46635,8 +54238,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.4607577,23.786346,16879.154};
-										angles[]={0,0.011324169,0};
+										position[]={24714.164,23.786392,13033.054};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46647,7 +54250,7 @@ class Mission
 									};
 									id=5868;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00028800964;
+									atlOffset=0.00045585632;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46677,8 +54280,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={8.6917152,23.786346,16879.168};
-										angles[]={0,0.011324169,0};
+										position[]={24714.076,23.786392,13030.824};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46689,7 +54292,7 @@ class Mission
 									};
 									id=5869;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00028800964;
+									atlOffset=0.00045585632;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46719,8 +54322,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={10.985538,23.786346,16879.107};
-										angles[]={0,0.011324169,0};
+										position[]={24713.914,23.786392,13028.531};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46731,7 +54334,7 @@ class Mission
 									};
 									id=5870;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00028800964;
+									atlOffset=0.00045585632;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46761,8 +54364,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.0703702,23.786591,16902.455};
-										angles[]={0,6.2710099,0};
+										position[]={24737.943,23.786636,13043.546};
+										angles[]={0,1.6026926,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46773,7 +54376,7 @@ class Mission
 									};
 									id=5871;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00053215027;
+									atlOffset=0.00063896179;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46803,8 +54406,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-0.53203988,23.786591,16902.535};
-										angles[]={0,6.2710118,0};
+										position[]={24737.824,23.786636,13039.011};
+										angles[]={0,1.6026945,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46815,7 +54418,7 @@ class Mission
 									};
 									id=5872;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00053215027;
+									atlOffset=0.000623703;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46845,8 +54448,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={1.7763097,23.786591,16902.541};
-										angles[]={0,6.2710118,0};
+										position[]={24737.73,23.786636,13036.703};
+										angles[]={0,1.6026945,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46857,7 +54460,7 @@ class Mission
 									};
 									id=5873;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00053215027;
+									atlOffset=0.000623703;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46887,8 +54490,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4.0105624,23.786407,16902.645};
-										angles[]={0,6.2710099,0};
+										position[]={24737.73,23.786453,13034.464};
+										angles[]={0,1.6026926,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46899,7 +54502,7 @@ class Mission
 									};
 									id=5874;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0003490448;
+									atlOffset=0.00044059753;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46929,8 +54532,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.3325839,23.786774,16902.668};
-										angles[]={0,6.2710099,0};
+										position[]={24737.656,23.786819,13032.145};
+										angles[]={0,1.6026926,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46941,7 +54544,7 @@ class Mission
 									};
 									id=5875;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00071525574;
+									atlOffset=0.00080680847;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46971,8 +54574,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={8.5712318,23.786407,16902.721};
-										angles[]={0,6.2710118,0};
+										position[]={24737.613,23.786453,13029.905};
+										angles[]={0,1.6026945,0};
 									};
 									side="Empty";
 									flags=4;
@@ -46983,7 +54586,7 @@ class Mission
 									};
 									id=5876;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0003490448;
+									atlOffset=0.00044059753;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47013,8 +54616,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={10.859196,23.786407,16902.717};
-										angles[]={0,6.2710118,0};
+										position[]={24737.508,23.786453,13027.621};
+										angles[]={0,1.6026945,0};
 									};
 									side="Empty";
 									flags=4;
@@ -47025,7 +54628,7 @@ class Mission
 									};
 									id=5877;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0003490448;
+									atlOffset=0.00044059753;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47055,8 +54658,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-6.1904874,23.786591,17028.018};
-										angles[]={0,1.5754142,0};
+										position[]={24863.434,23.786636,13039.136};
+										angles[]={0,3.1902819,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47066,7 +54669,7 @@ class Mission
 									};
 									id=5878;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.32141;
+									atlOffset=209.33743;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47096,8 +54699,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-6.1952481,23.786591,17025.719};
-										angles[]={0,1.5754193,0};
+										position[]={24861.141,23.786636,13039.24};
+										angles[]={0,3.1902871,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47107,7 +54710,7 @@ class Mission
 									};
 									id=5879;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.31834;
+									atlOffset=209.33743;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47137,8 +54740,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-6.1726651,23.786591,17023.484};
-										angles[]={0,1.5754193,0};
+										position[]={24858.904,23.786636,13039.317};
+										angles[]={0,3.1902871,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47148,7 +54751,7 @@ class Mission
 									};
 									id=5880;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.31537;
+									atlOffset=209.33743;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47178,8 +54781,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-6.222836,23.786591,17021.182};
-										angles[]={0,1.5754193,0};
+										position[]={24856.605,23.786636,13039.469};
+										angles[]={0,3.1902871,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47189,7 +54792,7 @@ class Mission
 									};
 									id=5881;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.3123;
+									atlOffset=209.33743;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47219,8 +54822,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-6.1589932,23.786377,17018.92};
-										angles[]={0,1.5754142,0};
+										position[]={24854.346,23.786423,13039.504};
+										angles[]={0,3.1902819,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47230,7 +54833,7 @@ class Mission
 									};
 									id=5882;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.30907;
+									atlOffset=209.33722;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47260,8 +54863,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.4915195,23.786652,17028.125};
-										angles[]={0,1.5466968,0};
+										position[]={24862.986,23.786697,13026.462};
+										angles[]={0,3.1615648,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47271,7 +54874,7 @@ class Mission
 									};
 									id=5883;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.32161;
+									atlOffset=209.33749;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47301,8 +54904,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.5331454,23.786652,17025.807};
-										angles[]={0,1.5466981,0};
+										position[]={24860.666,23.786697,13026.521};
+										angles[]={0,3.1615658,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47312,7 +54915,7 @@ class Mission
 									};
 									id=5884;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.31853;
+									atlOffset=209.33749;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47342,8 +54945,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.60712,23.786652,17023.563};
-										angles[]={0,1.5466981,0};
+										position[]={24858.42,23.786697,13026.544};
+										angles[]={0,3.1615658,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47353,7 +54956,7 @@ class Mission
 									};
 									id=5885;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.31552;
+									atlOffset=209.33749;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47383,8 +54986,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.6996493,23.786652,17021.305};
-										angles[]={0,1.5466981,0};
+										position[]={24856.16,23.786697,13026.553};
+										angles[]={0,3.1615658,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47394,7 +54997,7 @@ class Mission
 									};
 									id=5886;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.31252;
+									atlOffset=209.33749;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47424,8 +55027,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.7727695,23.786438,17019.051};
-										angles[]={0,1.5466968,0};
+										position[]={24853.908,23.786484,13026.581};
+										angles[]={0,3.1615648,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47435,7 +55038,7 @@ class Mission
 									};
 									id=5887;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.3093;
+									atlOffset=209.33728;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47465,8 +55068,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={7.1051669,23.786438,17017.314};
-										angles[]={0,1.1502779,0};
+										position[]={24852.156,23.786484,13026.323};
+										angles[]={0,2.7651453,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47476,7 +55079,7 @@ class Mission
 									};
 									id=5888;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.30699;
+									atlOffset=209.33728;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47506,8 +55109,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={8.222477,23.786438,17015.73};
-										angles[]={0,0.71384573,0};
+										position[]={24850.523,23.786484,13025.276};
+										angles[]={0,2.3287134,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47517,7 +55120,7 @@ class Mission
 									};
 									id=5889;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.30487;
+									atlOffset=209.33728;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47547,10 +55150,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.3336759,23.796295,16831.303};
-										angles[]={0,6.1776433,0};
+										position[]={24666.875,23.796341,13046.943};
+										angles[]={0,1.509326,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -47558,7 +55162,7 @@ class Mission
 									};
 									id=5890;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.06535;
+									atlOffset=0.00028800964;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47588,10 +55192,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.4856534,23.786041,16917.213};
-										angles[]={0,6.1776476,0};
+										position[]={24752.707,23.786087,13043.311};
+										angles[]={0,1.5093303,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -47599,7 +55204,7 @@ class Mission
 									};
 									id=5891;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.09312;
+									atlOffset=4.196167e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47629,8 +55234,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-7.6108975,22.102081,16954.402};
-										angles[]={0,0.011324169,0};
+										position[]={24789.955,22.102127,13043.794};
+										angles[]={0,1.6261921,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47640,7 +55245,7 @@ class Mission
 									};
 									id=5892;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=207.49461;
+									atlOffset=207.66792;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47670,8 +55275,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-6.0112882,23.799957,17016.514};
-										angles[]={0,1.5754193,0};
+										position[]={24851.936,23.800003,13039.459};
+										angles[]={0,3.1902871,0};
 									};
 									side="Empty";
 									flags=4;
@@ -47712,8 +55317,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.9603848,23.799744,17014.254};
-										angles[]={0,1.5754142,0};
+										position[]={24849.678,23.799789,13039.509};
+										angles[]={0,3.1902819,0};
 									};
 									side="Empty";
 									flags=4;
@@ -47751,7 +55356,7 @@ class Mission
 								};
 							};
 							id=4436;
-							atlOffset=209.07788;
+							atlOffset=209.13707;
 						};
 						class Item2
 						{
@@ -47765,8 +55370,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={65.197678,21.534424,17032.203};
-										angles[]={0,0.73110622,0};
+										position[]={24864.469,21.53447,12967.632};
+										angles[]={0,2.345974,0};
 									};
 									side="Empty";
 									flags=4;
@@ -47781,7 +55386,7 @@ class Mission
 									};
 									id=5895;
 									type="B_SAM_System_02_F";
-									atlOffset=0.00077819824;
+									atlOffset=0.00073623657;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47811,8 +55416,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-3.6874049,21.797714,17035.586};
-										angles[]={0,5.2469292,0};
+										position[]={24870.889,21.79776,13036.3};
+										angles[]={0,0.57861328,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47826,7 +55431,7 @@ class Mission
 									};
 									id=5896;
 									type="B_SAM_System_02_F";
-									atlOffset=205.79115;
+									atlOffset=205.79709;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47856,10 +55461,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-153.37994,21.025482,16568.932};
-										angles[]={0,3.2321832,0};
+										position[]={24411.281,21.025528,13206.405};
+										angles[]={0,4.8470564,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -47871,7 +55477,7 @@ class Mission
 									};
 									id=5897;
 									type="B_SAM_System_02_F";
-									atlOffset=0.26715279;
+									atlOffset=0.00349617;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47901,10 +55507,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-160.36182,11.73349,16471.23};
-										angles[]={0,3.2168229,0};
+										position[]={24313.986,11.733536,13217.679};
+										angles[]={0,4.8316956,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -47913,7 +55520,7 @@ class Mission
 									};
 									id=5898;
 									type="B_Ship_MRLS_01_F";
-									atlOffset=196.32999;
+									atlOffset=0.00067043304;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47943,8 +55550,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-162.06567,14.653656,16454.459};
-										angles[]={0,3.2237532,0};
+										position[]={24297.307,14.653702,13220.126};
+										angles[]={0,4.8386259,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47954,7 +55561,7 @@ class Mission
 									};
 									id=5899;
 									type="B_Ship_Gun_01_F";
-									atlOffset=197.88475;
+									atlOffset=190.70003;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47984,8 +55591,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.6541619,20.985809,16756.914};
-										angles[]={0,4.3501968,0};
+										position[]={24592.027,20.985855,13038.245};
+										angles[]={0,5.9650664,0};
 									};
 									side="Empty";
 									class Attributes
@@ -47999,7 +55606,7 @@ class Mission
 									};
 									id=5900;
 									type="B_SAM_System_01_F";
-									atlOffset=205.06535;
+									atlOffset=210.01187;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48029,8 +55636,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={61.195652,19.063736,16743.068};
-										angles[]={0,1.5882031,0};
+										position[]={24575.789,19.063782,12984.362};
+										angles[]={0,3.2030706,0};
 									};
 									side="Empty";
 									class Attributes
@@ -48044,7 +55651,7 @@ class Mission
 									};
 									id=5901;
 									type="B_AAA_System_01_F";
-									atlOffset=202.20866;
+									atlOffset=208.95129;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48074,8 +55681,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={83.280739,20.456146,16857.732};
-										angles[]={0,1.5882031,0};
+										position[]={24689.363,20.456192,12957.248};
+										angles[]={0,3.2030706,0};
 									};
 									side="Empty";
 									flags=4;
@@ -48090,7 +55697,7 @@ class Mission
 									};
 									id=5902;
 									type="B_AAA_System_01_F";
-									atlOffset=0.00070571899;
+									atlOffset=0.0024299622;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48120,8 +55727,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={5.7256827,19.971634,16752.326};
-										angles[]={0,4.69699,0};
+										position[]={24587.486,19.97168,13039.374};
+										angles[]={0,0.028674126,0};
 									};
 									side="Empty";
 									class Attributes
@@ -48135,15 +55742,15 @@ class Mission
 									};
 									id=5903;
 									type="B_AAA_System_01_F";
-									atlOffset=203.31535;
+									atlOffset=208.3154;
 								};
 								class Item9
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-151.39075,18.129547,16583.809};
-										angles[]={0,1.6760036,0};
+										position[]={24426.057,18.129593,13203.764};
+										angles[]={0,3.2908711,0};
 									};
 									side="Empty";
 									flags=4;
@@ -48158,7 +55765,7 @@ class Mission
 									};
 									id=5904;
 									type="B_AAA_System_01_F";
-									atlOffset=0.00040245056;
+									atlOffset=0.0041713715;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48188,8 +55795,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-157.85999,17.43219,16486.887};
-										angles[]={0,1.667854,0};
+										position[]={24329.51,17.432236,13214.497};
+										angles[]={0,3.2827215,0};
 									};
 									side="Empty";
 									flags=4;
@@ -48204,7 +55811,7 @@ class Mission
 									};
 									id=5905;
 									type="B_AAA_System_01_F";
-									atlOffset=0.00010585785;
+									atlOffset=0.0027751923;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48234,8 +55841,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-157.21765,21.025482,17231.732};
-										angles[]={0,3.2321832,0};
+										position[]={25073.605,21.025528,13181.042};
+										angles[]={0,4.8470564,0};
 									};
 									side="Empty";
 									class Attributes
@@ -48279,8 +55886,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-164.09241,11.73349,17134.137};
-										angles[]={0,3.2168229,0};
+										position[]={24976.414,11.733536,13192.202};
+										angles[]={0,4.8316956,0};
 									};
 									side="Empty";
 									class Attributes
@@ -48291,7 +55898,7 @@ class Mission
 									};
 									id=5907;
 									type="B_Ship_MRLS_01_F";
-									atlOffset=196.32999;
+									atlOffset=196.33003;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48321,8 +55928,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-165.70056,14.653656,17117.398};
-										angles[]={0,3.2237532,0};
+										position[]={24959.764,14.653702,13194.552};
+										angles[]={0,4.8386259,0};
 									};
 									side="Empty";
 									class Attributes
@@ -48332,7 +55939,7 @@ class Mission
 									};
 									id=5908;
 									type="B_Ship_Gun_01_F";
-									atlOffset=197.88475;
+									atlOffset=197.8848;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48362,8 +55969,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-155.22717,18.129547,17246.646};
-										angles[]={0,1.6760036,0};
+										position[]={25088.416,18.129593,13178.395};
+										angles[]={0,3.2908711,0};
 									};
 									side="Empty";
 									flags=4;
@@ -48408,8 +56015,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-162.32837,17.43219,17148.805};
-										angles[]={0,1.667854,0};
+										position[]={24990.986,17.432236,13189.796};
+										angles[]={0,3.2827215,0};
 									};
 									side="Empty";
 									flags=4;
@@ -48451,7 +56058,7 @@ class Mission
 								};
 							};
 							id=4467;
-							atlOffset=4.3739367;
+							atlOffset=4.374011;
 						};
 						class Item3
 						{
@@ -48465,8 +56072,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={1.30896,29.427063,16966.326};
-										angles[]={0,1.570915,0};
+										position[]={24801.475,29.427109,13034.359};
+										angles[]={0,3.1857829,0};
 									};
 									side="Empty";
 									class Attributes
@@ -48523,8 +56130,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-171.26477,10.474945,16523.895};
-										angles[]={0,1.5789473,6.0626497};
+										position[]={24367.078,10.474991,13226.257};
+										angles[]={6.039031,3.1987464,0.014241301};
 									};
 									side="Empty";
 									class Attributes
@@ -48532,7 +56139,7 @@ class Mission
 									};
 									id=5913;
 									type="UserTexture10m_F";
-									atlOffset=196.44495;
+									atlOffset=191.20731;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48581,8 +56188,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-174.71423,10.489227,17186.852};
-										angles[]={6.2831659,1.5947847,6.0137439};
+										position[]={25029.541,10.489273,13200.493};
+										angles[]={6.0215068,3.2170143,0.020227147};
 									};
 									side="Empty";
 									class Attributes
@@ -48590,7 +56197,7 @@ class Mission
 									};
 									id=5914;
 									type="UserTexture10m_F";
-									atlOffset=196.45923;
+									atlOffset=196.45927;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48639,8 +56246,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={8.2734375,23.838356,16973.943};
-										angles[]={0,3.1341057,0};
+										position[]={24808.779,23.838402,13027.065};
+										angles[]={0,4.7489786,0};
 									};
 									side="Empty";
 									flags=1;
@@ -48649,7 +56256,7 @@ class Mission
 									};
 									id=5915;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.65012;
+									atlOffset=208.76898;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48698,8 +56305,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={10.591553,23.853157,16974.002};
-										angles[]={0,3.1446702,0};
+										position[]={24808.736,23.853203,13024.748};
+										angles[]={0,4.7595434,0};
 									};
 									side="Empty";
 									flags=1;
@@ -48708,7 +56315,7 @@ class Mission
 									};
 									id=5916;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.662;
+									atlOffset=208.78383;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48757,8 +56364,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={3.5202637,23.880867,16973.947};
-										angles[]={0,3.1273766,0};
+										position[]={24808.992,23.880913,13031.815};
+										angles[]={0,4.7422495,0};
 									};
 									side="Empty";
 									flags=1;
@@ -48767,7 +56374,7 @@ class Mission
 									};
 									id=5917;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.69705;
+									atlOffset=208.80986;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48816,8 +56423,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.8085938,23.966866,16869.328};
-										angles[]={0,1.572928,0};
+										position[]={24704.885,23.966911,13045.745};
+										angles[]={0,3.1877956,0};
 									};
 									side="Empty";
 									flags=1;
@@ -48826,7 +56433,7 @@ class Mission
 									};
 									id=5918;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.58826;
+									atlOffset=210.15425;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48875,8 +56482,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.6700439,23.966866,16869.369};
-										angles[]={0,4.7143383,0};
+										position[]={24704.922,23.966911,13045.604};
+										angles[]={0,0.046022415,0};
 									};
 									side="Empty";
 									flags=1;
@@ -48885,7 +56492,7 @@ class Mission
 									};
 									id=5919;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.5883;
+									atlOffset=210.15479;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48934,8 +56541,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.3959961,23.966866,16910.496};
-										angles[]={0,1.5733267,0};
+										position[]={24745.994,23.966911,13043.519};
+										angles[]={0,3.1881943,0};
 									};
 									side="Empty";
 									flags=1;
@@ -48944,7 +56551,7 @@ class Mission
 									};
 									id=5920;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.64047;
+									atlOffset=209.27916;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -48993,8 +56600,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.2877197,23.966866,16910.471};
-										angles[]={0,4.7160463,0};
+										position[]={24745.963,23.966911,13043.406};
+										angles[]={0,0.047730446,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49003,7 +56610,7 @@ class Mission
 									};
 									id=5921;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.6404;
+									atlOffset=209.28021;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49052,8 +56659,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.4499512,24.392586,16828.563};
-										angles[]={0,0.21979976,0};
+										position[]={24664.1,24.392632,13046.182};
+										angles[]={0,1.8346677,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49063,7 +56670,7 @@ class Mission
 									};
 									id=5922;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.04346;
+									atlOffset=211.81158;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49112,8 +56719,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.8006592,24.392586,16829.521};
-										angles[]={0,2.3009443,0};
+										position[]={24665.072,24.392632,13046.488};
+										angles[]={0,3.9158125,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49123,7 +56730,7 @@ class Mission
 									};
 									id=5923;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.04218;
+									atlOffset=211.77475;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49172,8 +56779,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-3.7601318,24.392586,16829.295};
-										angles[]={0,4.394361,0};
+										position[]={24664.803,24.392632,13045.46};
+										angles[]={0,6.0092306,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49183,7 +56790,7 @@ class Mission
 									};
 									id=5924;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.04248;
+									atlOffset=211.80257;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49232,8 +56839,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-3.8588867,24.397774,16946.857};
-										angles[]={0,0.18323393,0};
+										position[]={24782.25,24.39782,13040.378};
+										angles[]={0,1.7981014,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49243,7 +56850,7 @@ class Mission
 									};
 									id=5925;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.14835;
+									atlOffset=209.36777;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49292,8 +56899,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.2438965,24.397774,16947.836};
-										angles[]={0,2.2644045,0};
+										position[]={24783.248,24.39782,13040.721};
+										angles[]={0,3.8792722,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49303,7 +56910,7 @@ class Mission
 									};
 									id=5926;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.15096;
+									atlOffset=209.36377;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49352,8 +56959,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-3.1854248,24.397774,16947.645};
-										angles[]={0,4.3576803,0};
+										position[]={24783.01,24.39782,13039.67};
+										angles[]={0,5.9725499,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49363,7 +56970,7 @@ class Mission
 									};
 									id=5927;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.15044;
+									atlOffset=209.36473;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49412,8 +57019,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={72.050781,24.392342,17014.947};
-										angles[]={0,2.7248528,0};
+										position[]={24846.932,24.392387,12961.543};
+										angles[]={0,4.3397207,0};
 									};
 									side="Empty";
 									flags=5;
@@ -49423,7 +57030,7 @@ class Mission
 									};
 									id=5928;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=8.7738037e-005;
+									atlOffset=8.5830688e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49472,8 +57079,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={72.904175,24.392342,17014.385};
-										angles[]={0,4.8061504,0};
+										position[]={24846.336,24.392387,12960.713};
+										angles[]={0,0.13783407,0};
 									};
 									side="Empty";
 									flags=5;
@@ -49532,8 +57139,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={71.943604,24.392342,17013.953};
-										angles[]={0,0.61635345,0};
+										position[]={24845.943,24.392387,12961.695};
+										angles[]={0,2.2312212,0};
 									};
 									side="Empty";
 									flags=5;
@@ -49543,7 +57150,7 @@ class Mission
 									};
 									id=5930;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=7.6293945e-006;
+									atlOffset=5.7220459e-006;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49592,8 +57199,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.447998,24.392586,16904.02};
-										angles[]={0,1.2040566,0};
+										position[]={24739.525,24.392632,13043.856};
+										angles[]={0,2.8189244,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49603,7 +57210,7 @@ class Mission
 									};
 									id=5931;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.05022;
+									atlOffset=209.8102;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49652,8 +57259,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.8223877,24.392586,16904.834};
-										angles[]={0,3.2853365,0};
+										position[]={24740.314,24.392632,13043.194};
+										angles[]={0,4.9002094,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49663,7 +57270,7 @@ class Mission
 									};
 									id=5932;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.05132;
+									atlOffset=209.79971;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49712,8 +57319,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.4331055,24.392586,16903.861};
-										angles[]={0,5.3787289,0};
+										position[]={24739.322,24.392632,13042.853};
+										angles[]={0,0.7104125,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49723,7 +57330,7 @@ class Mission
 									};
 									id=5933;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.05002;
+									atlOffset=209.8223;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49772,8 +57379,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.472534,24.392586,16961.082};
-										angles[]={0,0.036366828,0};
+										position[]={24792.924,24.392632,12959.501};
+										angles[]={0,1.6512346,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49783,7 +57390,7 @@ class Mission
 									};
 									id=5934;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.66989;
+									atlOffset=209.35368;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49832,8 +57439,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.002197,24.392586,16961.994};
-										angles[]={0,2.1175454,0};
+										position[]={24793.855,24.392632,12959.929};
+										angles[]={0,3.7324135,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49843,7 +57450,7 @@ class Mission
 									};
 									id=5935;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.68413;
+									atlOffset=209.35301;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49892,8 +57499,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={76.99646,24.392586,16961.965};
-										angles[]={0,4.2113323,0};
+										position[]={24793.783,24.392632,12958.936};
+										angles[]={0,5.8262019,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49903,7 +57510,7 @@ class Mission
 									};
 									id=5936;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.6667;
+									atlOffset=209.35178;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -49952,8 +57559,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={11.205688,28.156914,16968.922};
-										angles[]={0,4.705884,0};
+										position[]={24803.631,28.15696,13024.357};
+										angles[]={0,0.037568092,0};
 									};
 									side="Empty";
 									flags=1;
@@ -49992,8 +57599,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={11.404053,24.804314,16966.688};
-										angles[]={0,4.7138557,0};
+										position[]={24801.391,24.804359,13024.258};
+										angles[]={0,0.045539856,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50032,8 +57639,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.4921875,36.965141,16973.512};
-										angles[]={0,3.1490641,0};
+										position[]={24808.424,36.965187,13028.864};
+										angles[]={0,4.763937,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50072,8 +57679,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.3234863,24.501884,16953.33};
-										angles[]={0,0.0028530958,0};
+										position[]={24788.27,24.50193,13029.924};
+										angles[]={0,1.6177206,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50082,7 +57689,7 @@ class Mission
 									};
 									id=5940;
 									type="Land_Billboard_F";
-									atlOffset=208.55914;
+									atlOffset=208.75449;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50112,8 +57719,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-146.43445,12.101166,17185.957};
-										angles[]={0.0086942874,4.8359785,0.25332949};
+										position[]={25027.402,12.101212,13172.283};
+										angles[]={0.24353498,0.14910437,6.240273};
 									};
 									side="Empty";
 									class Attributes
@@ -50121,7 +57728,7 @@ class Mission
 									};
 									id=5941;
 									type="UserTexture10m_F";
-									atlOffset=198.07117;
+									atlOffset=198.07121;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50170,8 +57777,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-142.04443,9.7893982,16523.586};
-										angles[]={0,4.8051825,0.26696092};
+										position[]={24365.479,9.789444,13197.079};
+										angles[]={0.26443925,0.14152324,6.2446051};
 									};
 									side="Empty";
 									class Attributes
@@ -50179,7 +57786,7 @@ class Mission
 									};
 									id=5942;
 									type="UserTexture10m_F";
-									atlOffset=195.7594;
+									atlOffset=191.6788;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50228,8 +57835,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-0.515625,23.804283,17028.754};
-										angles[]={0,0.007670253,0};
+										position[]={24863.918,23.804329,13033.433};
+										angles[]={0,1.6225381,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50239,7 +57846,7 @@ class Mission
 									};
 									id=5943;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=208.71823;
+									atlOffset=208.73328;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50288,8 +57895,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.34778,24.693352,9391.8564};
-										angles[]={0,2.5925355,0};
+										position[]={14252.156,24.693352,12464.232};
+										angles[]={0,3.1411381,0};
 									};
 									side="Empty";
 									flags=5;
@@ -50299,7 +57906,7 @@ class Mission
 									};
 									id=5944;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=1.9073486e-005;
+									atlOffset=2.0980835e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50348,8 +57955,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={101.28333,24.693352,9391.4053};
-										angles[]={0,4.6740212,0};
+										position[]={14252.721,24.693352,12463.359};
+										angles[]={0,5.2226315,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50359,7 +57966,7 @@ class Mission
 									};
 									id=5945;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6223;
+									atlOffset=80.087486;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50408,8 +58015,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.38293,24.693352,9390.8428};
-										angles[]={0,0.48408461,0};
+										position[]={14251.658,24.693352,12463.347};
+										angles[]={0,1.0326773,0};
 									};
 									side="Empty";
 									flags=5;
@@ -50419,7 +58026,7 @@ class Mission
 									};
 									id=5946;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=2.2888184e-005;
+									atlOffset=2.6702881e-005;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50468,8 +58075,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.7166748,24.409035,16786.174};
-										angles[]={0,5.8510528,0};
+										position[]={24621.762,24.409081,13048.313};
+										angles[]={0,1.1827369,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50479,7 +58086,7 @@ class Mission
 									};
 									id=5947;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.14485;
+									atlOffset=213.10133;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50528,8 +58135,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-5.5965576,24.409035,16786.746};
-										angles[]={0,1.6492848,0};
+										position[]={24622.377,24.409081,13049.172};
+										angles[]={0,3.2641525,0};
 									};
 									side="Empty";
 									flags=5;
@@ -50539,7 +58146,7 @@ class Mission
 									};
 									id=5948;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=3.8146973e-006;
+									atlOffset=1.9073486e-006;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50588,8 +58195,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-4.6384277,24.409035,16787.207};
-										angles[]={0,3.7426176,0};
+										position[]={24622.791,24.409081,13048.191};
+										angles[]={0,5.3574872,0};
 									};
 									side="Empty";
 									flags=1;
@@ -50599,7 +58206,7 @@ class Mission
 									};
 									id=5949;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.14209;
+									atlOffset=213.07484;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50648,8 +58255,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={70.088989,23.664993,9328.0117};
-										angles[]={1.5707964,0,0.028536133};
+										position[]={14193.045,23.664993,12425.535};
+										angles[]={1.5707964,1.5112953e-007,5.7631407};
 									};
 									side="Empty";
 									flags=4;
@@ -50658,7 +58265,7 @@ class Mission
 									};
 									id=5950;
 									type="UserTexture10m_F";
-									atlOffset=0.0040035248;
+									atlOffset=0.0040054321;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50688,8 +58295,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={103.96692,23.672821,9181.7471};
-										angles[]={1.6155945,6.2373662,4.724164};
+										position[]={14145.678,23.672821,12283.067};
+										angles[]={4.71136,3.1414704,5.2492046};
 									};
 									side="Empty";
 									flags=4;
@@ -50728,8 +58335,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={33.459229,23.37941,16864.938};
-										angles[]={4.7120619,3.1414757,6.245707};
+										position[]={24698.77,23.379456,13006.707};
+										angles[]={4.9552374,3.3845272,1.5598507};
 									};
 									side="Empty";
 									flags=4;
@@ -50768,8 +58375,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={0.80480957,23.409561,16987.889};
-										angles[]={1.6038204,0.031751577,1.5548091};
+										position[]={24823.041,23.388033,13033.913};
+										angles[]={1.5711045,0.0014902296,6.2441187};
 									};
 									side="Empty";
 									flags=4;
@@ -50778,7 +58385,7 @@ class Mission
 									};
 									id=5953;
 									type="UserTexture10m_F";
-									atlOffset=0.042705536;
+									atlOffset=0.021131516;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -50805,7 +58412,7 @@ class Mission
 								};
 							};
 							id=4799;
-							atlOffset=209.4156;
+							atlOffset=120.89182;
 						};
 						class Item4
 						{
@@ -50819,8 +58426,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4.3576694,23.883423,16966.725};
-										angles[]={0,3.1967258,0};
+										position[]={24801.738,23.883469,13031.296};
+										angles[]={0,4.8115988,0};
 									};
 									side="Empty";
 									flags=4;
@@ -50860,8 +58467,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={3.4403663,23.979553,16967.971};
-										angles[]={0,4.9371176,0};
+										position[]={24803.021,23.979599,13032.156};
+										angles[]={0,0.26880169,0};
 									};
 									side="Empty";
 									flags=4;
@@ -50901,8 +58508,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4.8115234,24.450842,16966.668};
-										angles[]={0,6.0502105,0};
+										position[]={24801.662,24.450888,13030.848};
+										angles[]={0,1.3818941,0};
 									};
 									side="Empty";
 									flags=4;
@@ -50942,8 +58549,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4.1833496,24.548731,16966.451};
-										angles[]={0,3.1846409,0};
+										position[]={24801.471,24.548777,13031.48};
+										angles[]={0,4.7995138,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51002,8 +58609,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6.0355148,24.281555,16966.303};
-										angles[]={0,5.8466668,0};
+										position[]={24801.244,24.281601,13029.643};
+										angles[]={0,1.1783509,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51081,8 +58688,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={4.3054199,24.328217,16966.811};
-										angles[]={0,0.22664194,0};
+										position[]={24801.826,24.328262,13031.344};
+										angles[]={0,1.8415098,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51122,8 +58729,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={3.5994873,24.482422,16966.629};
-										angles[]={0,3.242785,0};
+										position[]={24801.676,24.482468,13032.059};
+										angles[]={0,4.8576579,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51167,8 +58774,8 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={35.5354,-0.16159058,16857.527};
-								angles[]={0,6.2816577,0};
+								position[]={24691.273,-0.1615448,13004.96};
+								angles[]={0,1.6133399,0};
 							};
 							side="Empty";
 							class Attributes
@@ -51177,15 +58784,15 @@ class Mission
 							};
 							id=5821;
 							type="Land_Carrier_01_base_F";
-							atlOffset=185.35413;
+							atlOffset=187.94289;
 						};
 						class Item6
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={-155.98486,-0.16159058,16533.209};
-								angles[]={0,0.071984932,0};
+								position[]={24375.709,-0.1615448,13210.583};
+								angles[]={0,1.6868529,0};
 							};
 							side="Empty";
 							class Attributes
@@ -51193,7 +58800,7 @@ class Mission
 							};
 							id=5822;
 							type="Land_Destroyer_01_base_F";
-							atlOffset=185.80841;
+							atlOffset=181.62877;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -51242,8 +58849,8 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={-159.66125,-0.16159058,17196.145};
-								angles[]={0,0.071984932,0};
+								position[]={25038.162,-0.1615448,13185.048};
+								angles[]={0,1.6868529,0};
 							};
 							side="Empty";
 							class Attributes
@@ -51251,7 +58858,7 @@ class Mission
 							};
 							id=5911;
 							type="Land_Destroyer_01_base_F";
-							atlOffset=185.80841;
+							atlOffset=185.80846;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -51295,17 +58902,1803 @@ class Mission
 								nAttributes=2;
 							};
 						};
+						class Item8
+						{
+							dataType="Layer";
+							name="NATO Marine Basen";
+							class Entities
+							{
+								items=4;
+								class Item0
+								{
+									dataType="Layer";
+									name="NATO Marine Base N";
+									id=3564;
+									atlOffset=185.97;
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={24450.693,-0.23620224,13180.269};
+										angles[]={0,3.2393885,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+										skill=0.60000002;
+									};
+									id=5252;
+									type="Land_HelipadCircle_F";
+									atlOffset=185.84721;
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={24442.021,9.1557426,13189.231};
+										angles[]={0,2.569243,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+										skill=0.60000002;
+										init="call{this setVariable [""opt_warehouse_data"", [""Marine-Ausrüstung"", ""sea"", west]]}";
+										disableSimulation=1;
+									};
+									id=5253;
+									type="Land_InfoStand_V1_F";
+									atlOffset=194.13345;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="ObjectTextureCustom0";
+											expression="_this setObjectTextureGlobal [0,_value]";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="opt_core\bilder\nato_nachschub.paa";
+												};
+											};
+										};
+										class Attribute1
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=2;
+									};
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={24441.967,8.9450979,13189.302};
+										angles[]={0,0.22090673,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+										aiRadarUsage=28025824;
+									};
+									id=5254;
+									type="Land_TyreBarrier_01_F";
+									atlOffset=0.019552231;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+							};
+							id=3549;
+							atlOffset=-12.489902;
+						};
+						class Item9
+						{
+							dataType="Layer";
+							name="N_basismodul";
+							class Entities
+							{
+								items=9;
+								class Item0
+								{
+									dataType="Layer";
+									name="N_absperrungen";
+									class Entities
+									{
+										items=1;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={24801.676,-2.4065399,13013.557};
+											name="respawn_west";
+											type="respawn_unknown";
+											colorName="ColorBlue";
+											angle=56.874039;
+											id=5255;
+											atlOffset=183.57455;
+										};
+									};
+									id=61;
+									atlOffset=183.57455;
+								};
+								class Item1
+								{
+									dataType="Layer";
+									name="N_sicherh_zonen";
+									class Entities
+									{
+										items=2;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={24694.785,328.90997,13022.125};
+											name="Todeszone_NATO_2";
+											markerType="ELLIPSE";
+											type="Empty";
+											colorName="ColorWEST";
+											alpha=0.19501862;
+											fillName="SolidBorder";
+											a=2000;
+											b=2000;
+											angle=253.65131;
+											drawBorder=1;
+											id=5256;
+											atlOffset=305.53296;
+										};
+										class Item1
+										{
+											dataType="Trigger";
+											position[]={24697.738,-174.31203,13012.758};
+											angle=-1.6474088;
+											class Attributes
+											{
+												text="CSAT Todeszone";
+												condition="call{vehicle player in thisList}";
+												onActivation="call{{player setDamage 1} foreach thisList; systemChat ""Ein CSAT Spieler wurde auf Grund des Betretens der feindlichen Basis automatisch getötet!""}";
+												sizeA=2000;
+												sizeB=2000;
+												timeout[]={10,10,10};
+												interuptable=1;
+												repeatable=1;
+												activationBy="EAST";
+											};
+											id=5257;
+											type="EmptyDetector";
+											atlOffset=13.487564;
+										};
+									};
+									id=152;
+									atlOffset=53.922035;
+								};
+								class Item2
+								{
+									dataType="Layer";
+									name="N_marker";
+									class Entities
+									{
+										items=2;
+										class Item0
+										{
+											dataType="Marker";
+											position[]={24728.096,330.67941,12997.233};
+											name="marker_nato_flagge_2";
+											type="flag_NATO";
+											angle=343.07477;
+											id=5259;
+											atlOffset=307.29807;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={24801.998,15.254105,13023.087};
+											name="marker_113";
+											type="b_unknown";
+											angle=146.6183;
+											id=5260;
+											atlOffset=201.23477;
+										};
+									};
+									id=157;
+									atlOffset=149.59987;
+								};
+								class Item3
+								{
+									dataType="Layer";
+									name="N_auslöser";
+									class Entities
+									{
+										items=5;
+										class Item0
+										{
+											dataType="Trigger";
+											position[]={24823.201,23.533997,13032.797};
+											angle=-4.6906943;
+											class Attributes
+											{
+												name="nato_trigger_Waffenwechsel2";
+												text="Trigger für Waffenwechsel-Dialog";
+												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
+												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=5.915;
+												sizeB=6;
+												sizeC=3.2160001;
+												repeatable=1;
+												activationBy="WEST";
+												isRectangle=1;
+											};
+											id=5261;
+											type="EmptyDetectorAreaR50";
+											atlOffset=0.16709518;
+										};
+										class Item1
+										{
+											dataType="Trigger";
+											position[]={24670.848,19.676346,13098.845};
+											angle=-4.5052595;
+											class Attributes
+											{
+												name="opt_warehouse_garbage_collector_4";
+												text="Löschbereich für Wracks Landebahn";
+												sizeA=276.939;
+												sizeB=485.70401;
+												repeatable=1;
+												activationBy="ANY";
+												isRectangle=1;
+											};
+											id=5262;
+											type="EmptyDetectorAreaR50";
+											atlOffset=206.94313;
+										};
+										class Item2
+										{
+											dataType="Trigger";
+											position[]={24699.838,24.132233,13007.096};
+											angle=-3.0845723;
+											class Attributes
+											{
+												name="nato_trigger_Waffenwechsel1";
+												text="Trigger für Waffenwechsel-Dialog";
+												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
+												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=6.0710001;
+												sizeB=6.2379999;
+												sizeC=6.717;
+												repeatable=1;
+												activationBy="WEST";
+												isRectangle=1;
+											};
+											id=5263;
+											type="EmptyDetectorAreaR50";
+											atlOffset=0.76533318;
+										};
+										class Item3
+										{
+											dataType="Trigger";
+											position[]={24699.592,23.377304,13006.642};
+											angle=-4.6535316;
+											class Attributes
+											{
+												name="trg_nato_repair_1";
+												text="Auslöser für Rep-Script";
+												condition="call{vehicle player in thislist && !isNull (objectParent player) && driver (vehicle player) == player && speed (vehicle player) < 0.1}";
+												onActivation="nul = [true] spawn opt_mission_fnc_repairSystem;";
+												onDeactivation="nul = [false] spawn opt_mission_fnc_repairSystem; ";
+												sizeA=5.2589998;
+												sizeB=5.1500001;
+												sizeC=8.2159996;
+												repeatable=1;
+												activationBy="WEST";
+												isRectangle=1;
+											};
+											id=5264;
+											type="EmptyDetectorArea10x10";
+											atlOffset=0.010404587;
+										};
+										class Item4
+										{
+											dataType="Trigger";
+											position[]={24855.906,24.042953,13033.611};
+											angle=-4.6741066;
+											class Attributes
+											{
+												name="nato_trigger_beam";
+												text="Trigger für Beam-Dialog";
+												condition="call{this && vehicle player in thislist}";
+												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=5.4885349;
+												sizeB=6.2888346;
+												sizeC=2.3541203;
+												repeatable=1;
+												activationBy="WEST";
+												isRectangle=1;
+											};
+											id=5265;
+											type="EmptyDetectorAreaR50";
+											atlOffset=0.66238976;
+										};
+									};
+									id=220;
+									atlOffset=0.2160778;
+								};
+								class Item4
+								{
+									dataType="Layer";
+									name="N_basis";
+									class Entities
+									{
+										items=8;
+										class Item0
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24766.436,23.366898,13031.674};
+												angles[]={0,3.1824617,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5266;
+											type="Land_HelipadCircle_F";
+											atlOffset=209.50043;
+										};
+										class Item1
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24680.832,23.377029,13036.247};
+												angles[]={0,3.1815581,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5267;
+											type="Land_HelipadCircle_F";
+											atlOffset=211.4626;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item2
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24726.01,23.366898,13032.627};
+												angles[]={0,3.1961112,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5268;
+											type="Land_HelipadCircle_F";
+											atlOffset=210.17844;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item3
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24812.203,23.366898,12967.735};
+												angles[]={0,0.029078484,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5269;
+											type="Land_HelipadCircle_F";
+											atlOffset=209.3369;
+										};
+										class Item4
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24790.197,23.748428,13022.151};
+												angles[]={0,3.971343,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												init="call{this addEventHandler [""ContainerClosed"", {params [""_container""]; clearWeaponCargoGlobal _container; clearMagazineCargoGlobal _container; clearItemCargoGlobal _container; clearBackpackCargoGlobal _container;  }]; this allowDamage false;}";
+											};
+											id=5270;
+											type="Box_NATO_Uniforms_F";
+											atlOffset=209.3633;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="ammoBox";
+													expression="[_this,_value] call bis_fnc_initAmmoBox;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"STRING"
+																};
+															};
+															value="[[[[],[]],[[],[]],[[],[]],[[],[]]],true]";
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item5
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24793.104,27.344145,13022.334};
+												angles[]={0,0.03638649,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												skill=0.60000002;
+												init="call{this allowDamage false;  [this, west] spawn opt_mhq_fnc_init; this addAction [""<t color='#00ff00' size='1.25'>Beam-System benutzen</t>"", {[] call opt_beam_fnc_openDialog}, false, 5, false, true, """"]; }";
+												name="homeflag_west";
+											};
+											id=5271;
+											type="Flag_NATO_F";
+											atlOffset=0.00043869019;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item6
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14241.975,23.651932,12471.057};
+												angles[]={0,0.48837146,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5272;
+											type="Land_HelipadCircle_F";
+											atlOffset=82.132439;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item7
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24621.387,23.367874,13037.696};
+												angles[]={0,4.7832613,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5273;
+											type="Land_HelipadCircle_F";
+											atlOffset=213.37427;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+									};
+									id=228;
+									atlOffset=60.654545;
+								};
+								class Item5
+								{
+									dataType="Layer";
+									name="N_entfernungs_module";
+									id=248;
+									atlOffset=185.97;
+								};
+								class Item6
+								{
+									dataType="Layer";
+									name="N_bestell_tische";
+									class Entities
+									{
+										items=4;
+										class Item0
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24783.082,23.772079,13039.406};
+												angles[]={0,5.9781246,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+											};
+											id=5274;
+											type="Land_CampingTable_small_F";
+											atlOffset=209.37456;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item1
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24740.33,23.772079,13043.121};
+												angles[]={0,4.9231567,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5275;
+											type="Land_CampingTable_small_F";
+											atlOffset=7.4386597e-005;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item2
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24792.742,23.772079,12959.507};
+												angles[]={0,1.6229882,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+											};
+											id=5276;
+											type="Land_CampingTable_small_F";
+											atlOffset=209.36923;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item3
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24664.246,23.782333,13046.064};
+												angles[]={0,1.7845254,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5277;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.00027275085;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+									};
+									id=267;
+									atlOffset=0.0052585602;
+								};
+								class Item7
+								{
+									dataType="Layer";
+									name="N_bestell_laptops";
+									class Entities
+									{
+										items=5;
+										class Item0
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24664.158,24.346212,13046.148};
+												angles[]={0,4.6854372,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Luftwaffe"", ""choppers"", west]]}";
+												disableSimulation=1;
+											};
+											id=5278;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=1.9073486e-006;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item1
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24782.955,24.335974,13039.494};
+												angles[]={0,2.5961967,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Panzer"", ""armored"", west]]}";
+												disableSimulation=1;
+											};
+											id=5279;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=1.7166138e-005;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item2
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24740.383,24.335974,13043.241};
+												angles[]={0,1.5412588,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Nachschub"", ""supplies"", west]]}";
+												disableSimulation=1;
+											};
+											id=5280;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=1.7166138e-005;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item3
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24792.73,24.335974,12959.573};
+												angles[]={0,4.5240259,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Rad-Fahrzeuge"", ""vehicles"", west]]}";
+												disableSimulation=1;
+											};
+											id=5281;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=1.7166138e-005;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item4
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24621.16,24.341568,13048.021};
+												angles[]={0,3.8876946,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Verkaufen"", ""sell"", west]]}";
+												disableSimulation=1;
+											};
+											id=5282;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=0.004442215;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+									};
+									id=289;
+									atlOffset=0.80632401;
+								};
+								class Item8
+								{
+									dataType="Layer";
+									name="N_modelle";
+									class Entities
+									{
+										items=5;
+										class Item0
+										{
+											dataType="Group";
+											side="East";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={24804.107,23.368336,13022.604};
+														angles[]={0,3.3347788,0};
+													};
+													side="East";
+													flags=3;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5284;
+													type="OPT_CSAT_Besatzungsmitglied";
+													atlOffset=209.34474;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male03PER";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=0.95999998;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												combatMode="BLUE";
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5283;
+											atlOffset=209.34474;
+										};
+										class Item1
+										{
+											dataType="Group";
+											side="East";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={24798.969,23.323902,13023.086};
+														angles[]={0,2.4526534,0};
+													};
+													side="East";
+													flags=2;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5286;
+													type="OPT_CSAT_Scharfschuetze";
+													atlOffset=209.30717;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male03PER";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=0.95999998;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5285;
+											atlOffset=209.30717;
+										};
+										class Item2
+										{
+											dataType="Group";
+											side="East";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={24800.426,23.323902,13022.428};
+														angles[]={0,3.4238567,6.2311378};
+													};
+													side="East";
+													flags=2;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5288;
+													type="OPT_CSAT_Grenadier";
+													atlOffset=209.30522;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male03PER";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=0.95999998;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5287;
+											atlOffset=209.30522;
+										};
+										class Item3
+										{
+											dataType="Group";
+											side="East";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={24802.701,23.323902,13022.645};
+														angles[]={0,2.8409061,0};
+													};
+													side="East";
+													flags=2;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5290;
+													type="OPT_CSAT_Pilot";
+													atlOffset=209.30219;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male03PER";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=0.95999998;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5289;
+											atlOffset=209.30219;
+										};
+										class Item4
+										{
+											dataType="Group";
+											side="East";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={24801.592,23.323963,13022.44};
+														angles[]={0,3.0970063,0};
+													};
+													side="East";
+													flags=3;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+														stance="Middle";
+														class Inventory
+														{
+															map="ItemMap";
+															compass="ItemCompass";
+															watch="ItemWatch";
+															radio="tf_fadak";
+															gps="ItemGPS";
+															headgear="H_StrawHat";
+														};
+													};
+													id=5292;
+													type="OPT_CSAT_Besatzungsmitglied";
+													atlOffset=209.30373;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male03PER";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=0.95999998;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5291;
+											atlOffset=209.30373;
+										};
+									};
+									id=295;
+									atlOffset=209.3063;
+								};
+							};
+							id=1;
+							atlOffset=196.07471;
+						};
+						class Item10
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={24786.119,24.191772,13021.679};
+								angles[]={0,2.5591259,0};
+							};
+							side="Empty";
+							class Attributes
+							{
+							};
+							id=5251;
+							type="OPT_B_CargoNet_01_ammo_F";
+							atlOffset=209.37383;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="ammoBox";
+									expression="[_this,_value] call bis_fnc_initAmmoBox;";
+									class Value
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="[[[[""OPT_hgun_P07_F""],[70]],[[""Laserbatteries""],[50]],[[""optic_ACO_grn_smg"",""optic_Aco_smg"",""optic_Holosight_smg_blk_F"",""optic_ACO_grn"",""optic_Aco"",""optic_Holosight_blk_F"",""optic_Arco_blk_F"",""optic_Hamr"",""optic_MRCO"",""optic_ERCO_blk_F"",""acc_flashlight"",""acc_pointer_IR"",""ACE_DefusalKit"",""ACE_wirecutter"",""NVGoggles""],[50,50,50,50,50,50,50,50,50,50,50,50,20,10,70]],[[""B_AssaultPack_rgr"",""TFAR_rt1523g_big_bwmod"",""ACE_TacticalLadder_Pack"",""B_Parachute""],[25,25,10,60]]],false]";
+										};
+									};
+								};
+								nAttributes=1;
+							};
+						};
 					};
 					id=4163;
-					atlOffset=188.20969;
+					atlOffset=195.14661;
 				};
-				class Item10
+				class Item8
 				{
 					dataType="Layer";
 					name="csat_carrier";
 					class Entities
 					{
-						items=11;
+						items=14;
 						class Item0
 						{
 							dataType="Layer";
@@ -51318,8 +60711,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={101.32829,24.080963,9346.1436};
-										angles[]={0,2.9966102,0};
+										position[]={14229.154,24.080963,12424.713};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51330,7 +60723,7 @@ class Mission
 									};
 									id=5965;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00050163269;
+									atlOffset=0.017145157;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51360,8 +60753,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={96.832199,24.080963,9345.4756};
-										angles[]={0,2.9966102,0};
+										position[]={14224.972,24.080963,12426.488};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51372,7 +60765,7 @@ class Mission
 									};
 									id=5966;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00050163269;
+									atlOffset=0.053766251;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51402,8 +60795,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={88.695389,24.080948,9318.835};
-										angles[]={0,0.089965343,0};
+										position[]={14204.135,24.080948,12408.002};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51414,7 +60807,7 @@ class Mission
 									};
 									id=5967;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0004940033;
+									atlOffset=0.021205902;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51444,8 +60837,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={91.000076,24.080948,9318.6123};
-										angles[]={0,0.089965343,0};
+										position[]={14205.986,24.080948,12406.609};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51456,7 +60849,7 @@ class Mission
 									};
 									id=5968;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0004863739;
+									atlOffset=0.0096092224;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51486,8 +60879,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={93.21492,24.080948,9318.4443};
-										angles[]={0,0.089965343,0};
+										position[]={14207.789,24.080948,12405.309};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51498,7 +60891,7 @@ class Mission
 									};
 									id=5969;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0004863739;
+									atlOffset=0.0096092224;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51528,8 +60921,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={95.617264,24.080887,9318.2568};
-										angles[]={0,0.089965343,0};
+										position[]={14209.743,24.080887,12403.898};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51540,7 +60933,7 @@ class Mission
 									};
 									id=5970;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00042533875;
+									atlOffset=0.005153656;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51570,8 +60963,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={94.617355,24.080521,9345.0928};
-										angles[]={0,2.9966073,0};
+										position[]={14222.883,24.080521,12427.316};
+										angles[]={0,3.5452168,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51582,7 +60975,7 @@ class Mission
 									};
 									id=5971;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=5.9127808e-005;
+									atlOffset=0.034643173;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51612,8 +61005,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={92.347824,24.08075,9344.7568};
-										angles[]={0,2.9966102,0};
+										position[]={14220.771,24.08075,12428.215};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51624,7 +61017,7 @@ class Mission
 									};
 									id=5972;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00028800964;
+									atlOffset=0.083608627;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51654,10 +61047,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={90.13884,24.08046,9344.4014};
-										angles[]={0,2.9966073,0};
+										position[]={14218.699,24.08046,12429.063};
+										angles[]={0,3.5452168,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -51665,7 +61059,7 @@ class Mission
 									};
 									id=5973;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.63126;
+									atlOffset=0.024160385;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51695,8 +61089,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={87.841965,24.08075,9344.0889};
-										angles[]={0,2.9966102,0};
+										position[]={14216.576,24.08075,12429.994};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51707,7 +61101,7 @@ class Mission
 									};
 									id=5974;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00028991699;
+									atlOffset=0.0010757446;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51737,8 +61131,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={97.783279,24.080734,9318.0615};
-										angles[]={0,0.089965343,0};
+										position[]={14211.485,24.080734,12402.602};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51749,7 +61143,7 @@ class Mission
 									};
 									id=5975;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00027275085;
+									atlOffset=0.0050010681;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51779,8 +61173,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.0489,24.080734,9317.8623};
-										angles[]={0,0.089965343,0};
+										position[]={14213.314,24.080734,12401.248};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51791,7 +61185,7 @@ class Mission
 									};
 									id=5976;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00027275085;
+									atlOffset=0.0030727386;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51821,8 +61215,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={102.28328,24.080734,9317.6865};
-										angles[]={0,0.089965343,0};
+										position[]={14215.129,24.080734,12399.936};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51833,7 +61227,7 @@ class Mission
 									};
 									id=5977;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00027275085;
+									atlOffset=0.003074646;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51863,8 +61257,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={104.70125,24.080673,9317.5029};
-										angles[]={0,0.089965343,0};
+										position[]={14217.098,24.080673,12398.518};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51875,7 +61269,7 @@ class Mission
 									};
 									id=5978;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0002117157;
+									atlOffset=0.0030117035;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51905,8 +61299,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={104.97865,24.07045,9260.0967};
-										angles[]={0,2.9966102,0};
+										position[]={14187.398,24.07045,12349.391};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51917,7 +61311,7 @@ class Mission
 									};
 									id=5979;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00022506714;
+									atlOffset=0.012992859;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51947,8 +61341,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={102.797,24.07045,9259.749};
-										angles[]={0,2.9966102,0};
+										position[]={14185.355,24.07045,12350.229};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -51959,7 +61353,7 @@ class Mission
 									};
 									id=5980;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00022506714;
+									atlOffset=0.012992859;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -51989,8 +61383,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.8595,24.070877,9259.4229};
-										angles[]={0,2.9966102,0};
+										position[]={14183.533,24.070877,12350.963};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52001,7 +61395,7 @@ class Mission
 									};
 									id=5981;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00065231323;
+									atlOffset=0.0076179504;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52031,8 +61425,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={92.836037,24.070862,9233.1143};
-										angles[]={0,0.089965343,0};
+										position[]={14162.966,24.070862,12332.7};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52043,7 +61437,7 @@ class Mission
 									};
 									id=5982;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00063896179;
+									atlOffset=0.0041351318;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52073,8 +61467,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={95.11731,24.070862,9232.9033};
-										angles[]={0,0.089965343,0};
+										position[]={14164.802,24.070862,12331.33};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52085,7 +61479,7 @@ class Mission
 									};
 									id=5983;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00063705444;
+									atlOffset=0.0041313171;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52115,8 +61509,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={97.365356,24.070862,9232.7334};
-										angles[]={0,0.089965343,0};
+										position[]={14166.632,24.070862,12330.012};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52127,7 +61521,7 @@ class Mission
 									};
 									id=5984;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00063705444;
+									atlOffset=0.0041313171;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52157,8 +61551,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.7677,24.070801,9232.542};
-										angles[]={0,0.089965343,0};
+										position[]={14168.582,24.070801,12328.596};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52169,7 +61563,7 @@ class Mission
 									};
 									id=5985;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00057601929;
+									atlOffset=0.009185791;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52199,8 +61593,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={98.666145,24.070663,9259.042};
-										angles[]={0,2.9966068,0};
+										position[]={14181.464,24.070663,12351.783};
+										angles[]={0,3.5452154,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52211,7 +61605,7 @@ class Mission
 									};
 									id=5986;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00043869019;
+									atlOffset=0.006565094;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52241,8 +61635,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={96.261848,24.070663,9258.665};
-										angles[]={0,2.9966102,0};
+										position[]={14179.215,24.070663,12352.716};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52253,7 +61647,7 @@ class Mission
 									};
 									id=5987;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00043869019;
+									atlOffset=0.0020179749;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52283,8 +61677,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={93.861458,24.070786,9258.4736};
-										angles[]={0,2.9966073,0};
+										position[]={14177.067,24.070786,12353.805};
+										angles[]={0,3.5452168,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52295,7 +61689,7 @@ class Mission
 									};
 									id=5988;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0005607605;
+									atlOffset=0.0021400452;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52325,8 +61719,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={91.589973,24.070663,9258.1729};
-										angles[]={0,2.9966102,0};
+										position[]={14174.969,24.070663,12354.729};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52337,7 +61731,7 @@ class Mission
 									};
 									id=5989;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00044250488;
+									atlOffset=0.0023345947;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52367,8 +61761,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={101.79309,24.070648,9232.3018};
-										angles[]={0,0.089965343,0};
+										position[]={14170.186,24.070648,12327.334};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52379,7 +61773,7 @@ class Mission
 									};
 									id=5990;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0004234314;
+									atlOffset=0.016994476;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52409,8 +61803,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={107.96692,24.070572,9232.0303};
-										angles[]={0,0.089965343,0};
+										position[]={14175.313,24.070572,12323.883};
+										angles[]={0,0.6385628,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52421,7 +61815,7 @@ class Mission
 									};
 									id=5991;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00034713745;
+									atlOffset=0.00073623657;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52451,8 +61845,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={27.752075,24.071014,9180.9307};
-										angles[]={0,6.1267586,0};
+										position[]={14080.221,24.071014,12322.113};
+										angles[]={0,0.39217201,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52463,7 +61857,7 @@ class Mission
 									};
 									id=5992;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00078582764;
+									atlOffset=0.01877594;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52493,8 +61887,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={29.978638,24.071014,9181.3154};
-										angles[]={0,6.1267586,0};
+										position[]={14082.323,24.071014,12321.281};
+										angles[]={0,0.39217201,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52505,7 +61899,7 @@ class Mission
 									};
 									id=5993;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00078582764;
+									atlOffset=0.01877594;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52535,8 +61929,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={32.255981,24.071014,9181.6514};
-										angles[]={0,6.1267586,0};
+										position[]={14084.435,24.071014,12320.378};
+										angles[]={0,0.39217201,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52547,7 +61941,7 @@ class Mission
 									};
 									id=5994;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00078582764;
+									atlOffset=0.01877594;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52577,10 +61971,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={37.882935,24.066666,9209.5068};
-										angles[]={0,3.2200451,0};
+										position[]={14103.768,24.066666,12341.214};
+										angles[]={0,3.7686553,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -52588,7 +61983,7 @@ class Mission
 									};
 									id=5995;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.61746;
+									atlOffset=0.02478981;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52618,10 +62013,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={35.699341,24.066849,9209.6689};
-										angles[]={0,3.2200444,0};
+										position[]={14101.988,24.066849,12342.49};
+										angles[]={0,3.7686548,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -52629,7 +62025,7 @@ class Mission
 									};
 									id=5996;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.61765;
+									atlOffset=0.024971008;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52659,10 +62055,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={33.300903,24.066605,9209.8076};
-										angles[]={0,3.2200451,0};
+										position[]={14100.016,24.066605,12343.859};
+										angles[]={0,3.7686553,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -52670,7 +62067,7 @@ class Mission
 									};
 									id=5997;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.6174;
+									atlOffset=0.024726868;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52700,8 +62097,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={34.46106,24.070801,9182.0791};
-										angles[]={0,6.1267471,0};
+										position[]={14086.543,24.070801,12319.594};
+										angles[]={0,0.3921614,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52712,7 +62109,7 @@ class Mission
 									};
 									id=5998;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00057220459;
+									atlOffset=0.016523361;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52742,8 +62139,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={36.748169,24.070801,9182.4229};
-										angles[]={0,6.1267586,0};
+										position[]={14088.674,24.070801,12318.695};
+										angles[]={0,0.39217201,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52754,7 +62151,7 @@ class Mission
 									};
 									id=5999;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00057220459;
+									atlOffset=0.016525269;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52784,8 +62181,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={38.964966,24.070801,9182.7979};
-										angles[]={0,6.1267586,0};
+										position[]={14090.76,24.070801,12317.859};
+										angles[]={0,0.39217201,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52796,7 +62193,7 @@ class Mission
 									};
 									id=6000;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00057220459;
+									atlOffset=0.015338898;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52826,8 +62223,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={41.203247,24.070801,9183.167};
-										angles[]={0,6.1267586,0};
+										position[]={14092.862,24.070801,12317.007};
+										angles[]={0,0.39217201,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52838,7 +62235,7 @@ class Mission
 									};
 									id=6001;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00057220459;
+									atlOffset=0.02249527;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52868,10 +62265,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={31.058716,24.066452,9209.9932};
-										angles[]={0,3.2200451,0};
+										position[]={14098.197,24.066452,12345.186};
+										angles[]={0,3.7686553,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -52879,7 +62277,7 @@ class Mission
 									};
 									id=6002;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.61725;
+									atlOffset=0.020149231;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52909,10 +62307,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={26.533325,24.066452,9210.3389};
-										angles[]={0,3.2200451,0};
+										position[]={14094.518,24.066452,12347.84};
+										angles[]={0,3.7686553,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -52920,7 +62319,7 @@ class Mission
 									};
 									id=6003;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.61725;
+									atlOffset=0.020149231;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52950,8 +62349,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.1251,24.071213,9298.71};
-										angles[]={0,3.1134417,0};
+										position[]={14207.66,24.071213,12382.262};
+										angles[]={0,3.6620505,0};
 									};
 									side="Empty";
 									flags=4;
@@ -52962,7 +62361,7 @@ class Mission
 									};
 									id=6004;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00098991394;
+									atlOffset=0.0038738251;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -52992,8 +62391,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={102.80283,24.071213,9298.5303};
-										angles[]={0,3.1134462,0};
+										position[]={14205.584,24.071213,12383.317};
+										angles[]={0,3.6620567,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53004,7 +62403,7 @@ class Mission
 									};
 									id=6005;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00098991394;
+									atlOffset=0.0010242462;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53034,8 +62433,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.55088,24.071213,9298.4287};
-										angles[]={0,3.1134462,0};
+										position[]={14203.607,24.071213,12384.408};
+										angles[]={0,3.6620567,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53046,7 +62445,7 @@ class Mission
 									};
 									id=6006;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00098991394;
+									atlOffset=0.010904312;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53076,8 +62475,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={98.255959,24.071213,9298.4053};
-										angles[]={0,3.1134462,0};
+										position[]={14201.641,24.071213,12385.584};
+										angles[]={0,3.6620567,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53088,7 +62487,7 @@ class Mission
 									};
 									id=6007;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00098991394;
+									atlOffset=0.011018753;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53118,8 +62517,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={96.021584,24.070999,9298.2764};
-										angles[]={0,3.1134417,0};
+										position[]={14199.67,24.070999,12386.641};
+										angles[]={0,3.6620505,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53130,7 +62529,7 @@ class Mission
 									};
 									id=6008;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00077629089;
+									atlOffset=0.01080513;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53160,8 +62559,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={93.701271,24.070999,9298.2021};
-										angles[]={0,3.1134462,0};
+										position[]={14197.648,24.070999,12387.783};
+										angles[]={0,3.6620567,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53172,7 +62571,7 @@ class Mission
 									};
 									id=6009;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00077629089;
+									atlOffset=0.01080513;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53202,8 +62601,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={91.46299,24.070999,9298.0967};
-										angles[]={0,3.1134462,0};
+										position[]={14195.684,24.070999,12388.863};
+										angles[]={0,3.6620567,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53214,7 +62613,7 @@ class Mission
 									};
 									id=6010;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00077629089;
+									atlOffset=0.0084056854;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53244,8 +62643,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={89.164139,24.070999,9298.0693};
-										angles[]={0,3.1134462,0};
+										position[]={14193.705,24.070999,12390.036};
+										angles[]={0,3.6620567,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53256,7 +62655,7 @@ class Mission
 									};
 									id=6011;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00077629089;
+									atlOffset=0.0091457367;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53286,8 +62685,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={106.11732,24.071274,9275.4248};
-										angles[]={0,3.089962,0};
+										position[]={14196.363,24.071274,12361.877};
+										angles[]={0,3.6385717,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53298,7 +62697,7 @@ class Mission
 									};
 									id=6012;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0010509491;
+									atlOffset=0.01099205;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53328,8 +62727,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={101.64661,24.071274,9275.1826};
-										angles[]={0,3.0899658,0};
+										position[]={14192.424,24.071274,12364};
+										angles[]={0,3.6385756,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53340,7 +62739,7 @@ class Mission
 									};
 									id=6013;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0010509491;
+									atlOffset=0.0070438385;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53370,8 +62769,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.336067,24.071274,9275.0967};
-										angles[]={0,3.0899658,0};
+										position[]={14190.406,24.071274,12365.132};
+										angles[]={0,3.6385756,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53382,7 +62781,7 @@ class Mission
 									};
 									id=6014;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.0010509491;
+									atlOffset=0.0070438385;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53412,8 +62811,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={97.099739,24.07106,9274.9209};
-										angles[]={0,3.089962,0};
+										position[]={14188.406,24.07106,12366.148};
+										angles[]={0,3.6385717,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53424,7 +62823,7 @@ class Mission
 									};
 									id=6015;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00083732605;
+									atlOffset=0.016084671;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53454,8 +62853,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={94.765755,24.07135,9274.7158};
-										angles[]={0,3.0899649,0};
+										position[]={14186.309,24.07135,12367.191};
+										angles[]={0,3.6385746,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53466,7 +62865,7 @@ class Mission
 									};
 									id=6016;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.001127243;
+									atlOffset=0.016374588;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53496,8 +62895,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={92.543098,24.07106,9274.6045};
-										angles[]={0,3.0899658,0};
+										position[]={14184.352,24.07106,12368.255};
+										angles[]={0,3.6385756,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53508,7 +62907,7 @@ class Mission
 									};
 									id=6017;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00083732605;
+									atlOffset=0.013067245;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53538,8 +62937,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={90.168098,24.07106,9274.5498};
-										angles[]={0,3.0899658,0};
+										position[]={14182.297,24.07106,12369.447};
+										angles[]={0,3.6385756,0};
 									};
 									side="Empty";
 									flags=4;
@@ -53550,7 +62949,7 @@ class Mission
 									};
 									id=6018;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00083732605;
+									atlOffset=0.0024356842;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53580,8 +62979,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.73254,24.071259,9150.3662};
-										angles[]={0,4.6967344,0};
+										position[]={14135.087,24.071259,12252.762};
+										angles[]={0,5.2453451,0};
 									};
 									side="Empty";
 									class Attributes
@@ -53591,7 +62990,7 @@ class Mission
 									};
 									id=6019;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62206;
+									atlOffset=66.923233;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53621,8 +63020,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.69543,24.071259,9152.6592};
-										angles[]={0,4.6967373,0};
+										position[]={14136.25,24.071259,12254.735};
+										angles[]={0,5.2453451,0};
 									};
 									side="Empty";
 									class Attributes
@@ -53632,7 +63031,7 @@ class Mission
 									};
 									id=6020;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62206;
+									atlOffset=67.106064;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53662,10 +63061,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.62122,24.071259,9154.9072};
-										angles[]={0,4.6967373,0};
+										position[]={14137.36,24.071259,12256.695};
+										angles[]={0,5.2453451,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -53673,7 +63073,7 @@ class Mission
 									};
 									id=6021;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62206;
+									atlOffset=0.0017299652;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53703,10 +63103,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.61731,24.071259,9157.2041};
-										angles[]={0,4.6967373,0};
+										position[]={14138.552,24.071259,12258.657};
+										angles[]={0,5.2453451,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -53714,7 +63115,7 @@ class Mission
 									};
 									id=6022;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62206;
+									atlOffset=0.0089206696;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53744,10 +63145,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.44543,24.071045,9159.4795};
-										angles[]={0,4.6967344,0};
+										position[]={14139.593,24.071045,12260.687};
+										angles[]={0,5.2453451,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -53755,7 +63157,7 @@ class Mission
 									};
 									id=6023;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62184;
+									atlOffset=0.0084819794;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53785,10 +63187,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.41418,24.071045,9161.7725};
-										angles[]={0,4.6967373,0};
+										position[]={14140.763,24.071045,12262.66};
+										angles[]={0,5.2453451,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -53796,7 +63199,7 @@ class Mission
 									};
 									id=6024;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62184;
+									atlOffset=0.014268875;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53826,10 +63229,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.63684,24.071045,9163.71};
-										angles[]={0,4.9597845,0};
+										position[]={14141.962,24.071045,12264.197};
+										angles[]={0,5.5083866,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -53837,7 +63241,7 @@ class Mission
 									};
 									id=6025;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62184;
+									atlOffset=0.014268875;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53867,8 +63271,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.41028,24.07132,9149.8096};
-										angles[]={0,4.6732521,0};
+										position[]={14125.987,24.07132,12257.67};
+										angles[]={0,5.2218618,0};
 									};
 									side="Empty";
 									class Attributes
@@ -53878,7 +63282,7 @@ class Mission
 									};
 									id=6026;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62212;
+									atlOffset=65.372154;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53908,8 +63312,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.3634,24.07132,9152.0146};
-										angles[]={0,4.6732578,0};
+										position[]={14127.098,24.07132,12259.576};
+										angles[]={0,5.2218685,0};
 									};
 									side="Empty";
 									class Attributes
@@ -53919,7 +63323,7 @@ class Mission
 									};
 									id=6027;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62212;
+									atlOffset=65.389633;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53949,8 +63353,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.24622,24.07132,9154.2666};
-										angles[]={0,4.6732578,0};
+										position[]={14128.173,24.07132,12261.558};
+										angles[]={0,5.2218685,0};
 									};
 									side="Empty";
 									class Attributes
@@ -53960,7 +63364,7 @@ class Mission
 									};
 									id=6028;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62212;
+									atlOffset=65.36293;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -53990,8 +63394,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.02551,24.07132,9156.5342};
-										angles[]={0,4.6732578,0};
+										position[]={14129.164,24.07132,12263.609};
+										angles[]={0,5.2218685,0};
 									};
 									side="Empty";
 									class Attributes
@@ -54001,7 +63405,7 @@ class Mission
 									};
 									id=6029;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.62212;
+									atlOffset=65.189537;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54031,8 +63435,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.02356,24.071106,9158.792};
-										angles[]={0,4.6732521,0};
+										position[]={14130.342,24.071106,12265.537};
+										angles[]={0,5.2218618,0};
 									};
 									side="Empty";
 									class Attributes
@@ -54042,7 +63446,7 @@ class Mission
 									};
 									id=6030;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.6219;
+									atlOffset=64.949196;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54072,8 +63476,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.683716,24.071106,9160.5049};
-										angles[]={0,4.276773,0};
+										position[]={14130.944,24.071106,12267.175};
+										angles[]={0,4.8253841,0};
 									};
 									side="Empty";
 									class Attributes
@@ -54083,7 +63487,7 @@ class Mission
 									};
 									id=6031;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.6219;
+									atlOffset=64.662788;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54113,8 +63517,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={98.566528,24.071106,9162.0791};
-										angles[]={0,3.8402619,0};
+										position[]={14130.811,24.071106,12269.1};
+										angles[]={0,4.3888597,0};
 									};
 									side="Empty";
 									class Attributes
@@ -54124,7 +63528,7 @@ class Mission
 									};
 									id=6032;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=209.6219;
+									atlOffset=64.34198;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54154,8 +63558,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={103.60368,24.080963,9346.4678};
-										angles[]={0,2.9966068,0};
+										position[]={14231.266,24.080963,12423.803};
+										angles[]={0,3.5452154,0};
 									};
 									side="Empty";
 									flags=4;
@@ -54166,7 +63570,7 @@ class Mission
 									};
 									id=6033;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00050163269;
+									atlOffset=0.0053005219;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54196,8 +63600,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={107.00013,24.070724,9260.3975};
-										angles[]={0,2.9966102,0};
+										position[]={14189.277,24.070724,12348.593};
+										angles[]={0,3.5452189,0};
 									};
 									side="Empty";
 									flags=4;
@@ -54208,7 +63612,7 @@ class Mission
 									};
 									id=6034;
 									type="PlasticBarrier_03_orange_F";
-									atlOffset=0.00049972534;
+									atlOffset=0.013267517;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54235,7 +63639,7 @@ class Mission
 								};
 							};
 							id=4793;
-							atlOffset=0.0031604767;
+							atlOffset=0.012237549;
 						};
 						class Item1
 						{
@@ -54249,8 +63653,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={95.470825,24.123024,9203.5908};
-										angles[]={0,6.2362957,0};
+										position[]={14149.82,24.123024,12306.134};
+										angles[]={0,0.50170809,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54259,7 +63663,7 @@ class Mission
 									};
 									id=6035;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.05197;
+									atlOffset=61.263378;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54308,8 +63712,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={93.166138,24.137794,9203.4443};
-										angles[]={0,6.2468538,0};
+										position[]={14147.776,24.137794,12307.209};
+										angles[]={0,0.51226628,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54318,7 +63722,7 @@ class Mission
 									};
 									id=6036;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.06674;
+									atlOffset=61.426327;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54367,8 +63771,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={100.21887,24.165535,9203.7959};
-										angles[]={0,6.2295685,0};
+										position[]={14153.977,24.165535,12303.832};
+										angles[]={0,0.49498135,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54377,7 +63781,7 @@ class Mission
 									};
 									id=6037;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.09448;
+									atlOffset=61.094269;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54426,8 +63830,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.42004,24.251503,9308.6885};
-										angles[]={0,4.6751671,0};
+										position[]={14213.113,24.251503,12390.623};
+										angles[]={0,5.2237797,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54436,7 +63840,7 @@ class Mission
 									};
 									id=6038;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.18045;
+									atlOffset=58.201954;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54485,8 +63889,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.28333,24.251427,9308.6279};
-										angles[]={0,1.5333407,0};
+										position[]={14212.967,24.251427,12390.64};
+										angles[]={0,2.0819275,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54495,7 +63899,7 @@ class Mission
 									};
 									id=6039;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.18037;
+									atlOffset=58.210358;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54544,8 +63948,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={106.63098,24.251503,9267.5361};
-										angles[]={0,4.6755672,0};
+										position[]={14192.688,24.251503,12354.878};
+										angles[]={0,5.2241783,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54554,7 +63958,7 @@ class Mission
 									};
 									id=6040;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.18045;
+									atlOffset=62.791836;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54603,8 +64007,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={106.52161,24.251701,9267.5381};
-										angles[]={0,1.5350511,0};
+										position[]={14192.596,24.251701,12354.938};
+										angles[]={0,2.083638,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54613,7 +64017,7 @@ class Mission
 									};
 									id=6041;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.18065;
+									atlOffset=62.796112;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54662,8 +64066,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={102.46106,24.677254,9349.3721};
-										angles[]={0,3.3219185,0};
+										position[]={14231.807,24.677254,12426.878};
+										angles[]={0,3.8705292,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54673,7 +64077,7 @@ class Mission
 									};
 									id=6042;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=61.959145;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54722,8 +64126,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={102.85168,24.677254,9348.4111};
-										angles[]={0,5.4031858,0};
+										position[]={14231.639,24.677254,12425.854};
+										angles[]={0,5.9517879,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54733,7 +64137,7 @@ class Mission
 									};
 									id=6043;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=61.801178;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54782,8 +64186,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={101.80676,24.677254,9348.6025};
-										angles[]={0,1.2133756,0};
+										position[]={14230.849,24.677254,12426.561};
+										angles[]={0,1.7619616,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54793,7 +64197,7 @@ class Mission
 									};
 									id=6044;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=61.898212;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54842,8 +64246,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={106.52161,24.682411,9231.1436};
-										angles[]={0,3.2853527,0};
+										position[]={14173.615,24.682411,12323.879};
+										angles[]={0,3.8339634,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54853,7 +64257,7 @@ class Mission
 									};
 									id=6045;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.61136;
+									atlOffset=65.753784;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54902,8 +64306,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={106.93958,24.682411,9230.1826};
-										angles[]={0,5.3666487,0};
+										position[]={14173.472,24.682411,12322.842};
+										angles[]={0,5.9152517,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54913,7 +64317,7 @@ class Mission
 									};
 									id=6046;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.61136;
+									atlOffset=65.769104;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -54962,8 +64366,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.88489,24.682411,9230.3193};
-										angles[]={0,1.1767106,0};
+										position[]={14172.645,24.682411,12323.512};
+										angles[]={0,1.7252964,0};
 									};
 									side="Empty";
 									flags=1;
@@ -54973,7 +64377,7 @@ class Mission
 									};
 									id=6047;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.61136;
+									atlOffset=65.574066;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55022,8 +64426,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={33.355591,24.676979,9160.1201};
-										angles[]={0,5.8270617,0};
+										position[]={14074.15,24.676979,12301.436};
+										angles[]={0,0.092476256,0};
 									};
 									side="Empty";
 									flags=5;
@@ -55082,8 +64486,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={32.474731,24.676979,9160.6455};
-										angles[]={0,1.6251556,0};
+										position[]={14073.67,24.676979,12302.342};
+										angles[]={0,2.1737418,0};
 									};
 									side="Empty";
 									flags=5;
@@ -55142,8 +64546,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={33.421997,24.676979,9161.1025};
-										angles[]={0,3.718472,0};
+										position[]={14074.72,24.676979,12302.238};
+										angles[]={0,4.2670698,0};
 									};
 									side="Empty";
 									flags=5;
@@ -55202,8 +64606,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={106.422,24.677254,9274.0146};
-										angles[]={0,4.3062491,0};
+										position[]={14195.887,24.677254,12360.512};
+										angles[]={0,4.8548594,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55213,7 +64617,7 @@ class Mission
 									};
 									id=6051;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=62.116131;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55262,8 +64666,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.83606,24.677254,9273.1748};
-										angles[]={0,0.10432959,0};
+										position[]={14194.951,24.677254,12360.104};
+										angles[]={0,0.65292686,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55273,7 +64677,7 @@ class Mission
 									};
 									id=6052;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=62.275139;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55322,8 +64726,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.40442,24.677254,9274.1299};
-										angles[]={0,2.1977429,0};
+										position[]={14195.082,24.677254,12361.144};
+										angles[]={0,2.7463288,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55333,7 +64737,7 @@ class Mission
 									};
 									id=6053;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=62.128391;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55382,8 +64786,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={26.816528,24.677254,9213.7646};
-										angles[]={0,3.1384861,0};
+										position[]={14096.541,24.677254,12350.616};
+										angles[]={0,3.6870968,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55393,7 +64797,7 @@ class Mission
 									};
 									id=6054;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=72.896194;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55442,8 +64846,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={27.328247,24.677254,9212.8604};
-										angles[]={0,5.2197876,0};
+										position[]={14096.511,24.677254,12349.578};
+										angles[]={0,5.7683897,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55453,7 +64857,7 @@ class Mission
 									};
 									id=6055;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=72.376411;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55502,8 +64906,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={26.322388,24.677254,9212.8643};
-										angles[]={0,1.0303607,0};
+										position[]={14095.654,24.677254,12350.107};
+										angles[]={0,1.5789466,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55513,7 +64917,7 @@ class Mission
 									};
 									id=6056;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.6062;
+									atlOffset=72.621574;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55562,8 +64966,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.18372,24.418556,9149.5068};
-										angles[]={0,3.0721378,0};
+										position[]={14129.904,24.418556,12254.922};
+										angles[]={0,3.620748,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55573,7 +64977,7 @@ class Mission
 									};
 									id=6057;
 									type="SignAd_Sponsor_Vrana_F";
-									atlOffset=209.3475;
+									atlOffset=65.662453;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55622,8 +65026,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={92.347778,28.441582,9208.501};
-										angles[]={0,1.5248891,0};
+										position[]={14149.715,28.441582,12311.951};
+										angles[]={0,2.0734758,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55662,8 +65066,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={92.062622,25.08886,9210.7197};
-										angles[]={0,1.5328519,0};
+										position[]={14150.629,25.08886,12313.994};
+										angles[]={0,2.0814385,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55702,8 +65106,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={97.224731,37.249596,9204.1045};
-										angles[]={0,6.2512455,0};
+										position[]={14151.582,37.249596,12305.658};
+										angles[]={0,0.51665789,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55742,8 +65146,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={96.609497,24.787117,9224.2764};
-										angles[]={0,3.1049922,0};
+										position[]={14161.577,24.787117,12323.193};
+										angles[]={0,3.6536014,0};
 									};
 									side="Empty";
 									flags=1;
@@ -55752,7 +65156,7 @@ class Mission
 									};
 									id=6061;
 									type="Land_Billboard_F";
-									atlOffset=209.01393;
+									atlOffset=63.09771;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55782,8 +65186,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={102.13293,29.712006,9211.4775};
-										angles[]={0,4.6731524,0};
+										position[]={14159.615,29.712006,12309.39};
+										angles[]={0,5.2217655,0};
 									};
 									side="Empty";
 									class Attributes
@@ -55840,8 +65244,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={286.79309,10.89183,8998.0635};
-										angles[]={0,4.6987395,0.24961618};
+										position[]={14531.191,10.768539,12587.092};
+										angles[]={0.13217248,5.2614584,0.21236689};
 									};
 									side="Empty";
 									class Attributes
@@ -55849,7 +65253,7 @@ class Mission
 									};
 									id=6063;
 									type="UserTexture10m_F";
-									atlOffset=196.86183;
+									atlOffset=66.746078;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55898,8 +65302,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={256.95911,10.661865,9660.0439};
-										angles[]={0,4.6987395,0.27838135};
+										position[]={14197.246,10.53894,12003.298};
+										angles[]={0.14795694,5.2649736,0.2366706};
 									};
 									side="Empty";
 									class Attributes
@@ -55907,7 +65311,7 @@ class Mission
 									};
 									id=6064;
 									type="UserTexture10m_F";
-									atlOffset=196.63187;
+									atlOffset=66.967041;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -55956,8 +65360,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={257.75989,10.391022,8998.0107};
-										angles[]={0,1.6286316,6.035234};
+										position[]={14506.389,10.267731,12602.187};
+										angles[]={6.1519427,2.1911328,6.0722265};
 									};
 									side="Empty";
 									class Attributes
@@ -55965,7 +65369,7 @@ class Mission
 									};
 									id=6065;
 									type="UserTexture10m_F";
-									atlOffset=196.36102;
+									atlOffset=60.937611;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56014,8 +65418,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={227.90247,9.838501,9660.415};
-										angles[]={0,1.6286316,6.0270882};
+										position[]={14172.646,9.7155762,12018.77};
+										angles[]={6.1474919,2.1920795,6.0653377};
 									};
 									side="Empty";
 									class Attributes
@@ -56023,7 +65427,7 @@ class Mission
 									};
 									id=6066;
 									type="UserTexture10m_F";
-									atlOffset=195.8085;
+									atlOffset=64.503403;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56072,8 +65476,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={91.091919,32.869553,9226.1709};
-										angles[]={6.0911994,1.547217,0};
+										position[]={14157.859,32.869553,12327.686};
+										angles[]={6.1188445,2.0875893,0.099661455};
 									};
 									side="Empty";
 									class Attributes
@@ -56128,7 +65532,7 @@ class Mission
 								};
 							};
 							id=4794;
-							atlOffset=208.04762;
+							atlOffset=63.561474;
 						};
 						class Item2
 						{
@@ -56147,22 +65551,22 @@ class Mission
 										class Item0
 										{
 											dataType="Marker";
-											position[]={62.008057,31.472,9289.79};
+											position[]={14166.217,31.472,12397.135};
 											name="marker_csat_flagge";
 											type="flag_CSAT";
-											angle=87.231972;
+											angle=118.66359;
 											id=6072;
 											atlOffset=7.807127;
 										};
 										class Item1
 										{
 											dataType="Marker";
-											position[]={95.158325,19.913635,9288.4697};
+											position[]={14193.814,19.913635,12378.723};
 											name="marker_116";
 											type="o_service";
-											angle=86.256607;
+											angle=117.68831;
 											id=6073;
-											atlOffset=205.88364;
+											atlOffset=58.07774;
 										};
 									};
 									id=724;
@@ -56171,84 +65575,84 @@ class Mission
 								class Item1
 								{
 									dataType="Marker";
-									position[]={96.308716,0.12307739,9210.3389};
+									position[]={14154.053,0.12307739,12311.455};
 									name="marker_12";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=19.156418;
 									b=10.26421;
-									angle=86.273224;
+									angle=117.70492;
 									id=6068;
-									atlOffset=186.09308;
+									atlOffset=38.988472;
 								};
 								class Item2
 								{
 									dataType="Marker";
-									position[]={53.394653,-1.697052,9528.2178};
+									position[]={14283.206,-1.697052,12605.069};
 									name="marker_13";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=64.534431;
 									b=32.28862;
-									angle=267.57785;
+									angle=299.01093;
 									id=6069;
-									atlOffset=184.27295;
+									atlOffset=24.499771;
 								};
 								class Item3
 								{
 									dataType="Marker";
-									position[]={73.525513,-11.850525,9107.4209};
+									position[]={14080.943,-11.850525,12235.52};
 									name="marker_17";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=10.244446;
 									b=32.28862;
-									angle=267.57785;
+									angle=299.01093;
 									id=6070;
-									atlOffset=174.11948;
+									atlOffset=32.485878;
 								};
 								class Item4
 								{
 									dataType="Marker";
-									position[]={63.982544,-0.4604187,9290.5811};
+									position[]={14168.314,-0.4604187,12396.781};
 									name="marker_7";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=49.559002;
 									b=174.3134;
-									angle=357.09723;
+									angle=28.529509;
 									id=6071;
-									atlOffset=185.50958;
+									atlOffset=45.11092;
 								};
 								class Item5
 								{
 									dataType="Marker";
-									position[]={274.86145,-0.2220459,8998.4248};
+									position[]={14521.198,-0.34533691,12593.623};
 									name="marker_15";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=109.08534;
 									b=19.220396;
-									angle=93.087608;
+									angle=124.51923;
 									id=6074;
-									atlOffset=185.74796;
+									atlOffset=51.237946;
 								};
 								class Item6
 								{
 									dataType="Marker";
-									position[]={241.44934,-0.2220459,9649.999};
+									position[]={14178.774,-0.3449707,12002.813};
 									name="marker_18";
 									markerType="RECTANGLE";
 									type="rectangle";
 									a=114.72881;
 									b=23.83993;
-									angle=90.49144;
+									angle=121.92308;
 									id=6075;
-									atlOffset=185.74796;
+									atlOffset=55.655506;
 								};
 							};
 							id=4795;
-							atlOffset=185.35559;
+							atlOffset=44.823624;
 						};
 						class Item3
 						{
@@ -56262,8 +65666,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={41.097778,21.818939,9142.7197};
-										angles[]={0,3.8332658,0};
+										position[]={14071.682,21.818939,12282.55};
+										angles[]={0,4.3818636,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56278,7 +65682,7 @@ class Mission
 									};
 									id=6076;
 									type="B_SAM_System_02_F";
-									atlOffset=0.0009765625;
+									atlOffset=0.073787689;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56308,8 +65712,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.82239,22.083099,9142.1885};
-										angles[]={0,2.0659463,0};
+										position[]={14130.898,22.083099,12245.737};
+										angles[]={0,2.6145329,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56324,7 +65728,7 @@ class Mission
 									};
 									id=6077;
 									type="B_SAM_System_02_F";
-									atlOffset=0.0010681152;
+									atlOffset=0.04381752;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56354,10 +65758,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={241.05872,21.31012,9613.9619};
-										angles[]={0,0.051177502,0};
+										position[]={14159.65,21.187195,11972.269};
+										angles[]={0,0.59977448,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -56369,7 +65774,7 @@ class Mission
 									};
 									id=6078;
 									type="B_SAM_System_02_F";
-									atlOffset=0.26730537;
+									atlOffset=0.011331558;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56399,10 +65804,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={271.25598,21.31012,8952.9092};
-										angles[]={0,0.051177502,0};
+										position[]={14494.384,21.186829,12556.666};
+										angles[]={0,0.59977448,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -56414,7 +65820,7 @@ class Mission
 									};
 									id=6079;
 									type="B_SAM_System_02_F";
-									atlOffset=0.26693916;
+									atlOffset=0.08389473;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56444,8 +65850,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={244.0177,12.018143,9712.5693};
-										angles[]={0,0.035815716,0};
+										position[]={14213.602,11.895218,12054.863};
+										angles[]={0,0.58441377,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56457,7 +65863,7 @@ class Mission
 									};
 									id=6080;
 									type="B_Ship_MRLS_01_F";
-									atlOffset=0.00010108948;
+									atlOffset=0.048931122;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56487,8 +65893,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={274.20715,12.018143,9050.1787};
-										angles[]={0,0.035815716,0};
+										position[]={14547.631,11.894852,12638.123};
+										angles[]={0,0.58441377,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56500,7 +65906,7 @@ class Mission
 									};
 									id=6081;
 									type="B_Ship_MRLS_01_F";
-									atlOffset=0.00033855438;
+									atlOffset=0.0029306412;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56530,10 +65936,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={245.66028,14.938309,9729.0244};
-										angles[]={0,0.042595387,0};
+										position[]={14223.58,14.815384,12068.049};
+										angles[]={0,0.5911932,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										disableSimulation=1;
@@ -56541,7 +65948,7 @@ class Mission
 									};
 									id=6082;
 									type="B_Ship_Gun_01_F";
-									atlOffset=198.1694;
+									atlOffset=0.082154274;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56571,8 +65978,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={275.18372,14.938309,9067.4893};
-										angles[]={0,0.042595387,0};
+										position[]={14557.488,14.815018,12652.385};
+										angles[]={0,0.5911932,0};
 									};
 									side="Empty";
 									class Attributes
@@ -56582,7 +65989,7 @@ class Mission
 									};
 									id=6083;
 									type="B_Ship_Gun_01_F";
-									atlOffset=198.1694;
+									atlOffset=66.018707;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56612,10 +66019,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={88.6427,21.270752,9420.2041};
-										angles[]={0,1.1692309,0};
+										position[]={14256.954,21.270752,12494.522};
+										angles[]={0,1.7178173,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -56627,7 +66035,7 @@ class Mission
 									};
 									id=6084;
 									type="B_SAM_System_01_F";
-									atlOffset=205.48428;
+									atlOffset=0.071529388;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56657,10 +66065,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={33.937618,19.363663,9432.0342};
-										angles[]={0,4.6904325,0};
+										position[]={14216.444,19.363663,12533.145};
+										angles[]={0,5.2390442,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -56672,7 +66081,7 @@ class Mission
 									};
 									id=6085;
 									type="B_AAA_System_01_F";
-									atlOffset=202.82791;
+									atlOffset=0.19035339;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56702,8 +66111,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={16.720825,20.702957,9316.3135};
-										angles[]={0,4.6904325,0};
+										position[]={14141.406,20.702957,12443.383};
+										angles[]={0,5.2390442,0};
 									};
 									side="Empty";
 									class Attributes
@@ -56717,7 +66126,7 @@ class Mission
 									};
 									id=6086;
 									type="B_AAA_System_01_F";
-									atlOffset=204.16721;
+									atlOffset=0.99105453;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56747,10 +66156,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={89.601685,20.256073,9425.0576};
-										angles[]={0,1.515993,0};
+										position[]={14260.301,20.256073,12498.163};
+										angles[]={0,2.0645804,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -56762,15 +66172,15 @@ class Mission
 									};
 									id=6087;
 									type="B_AAA_System_01_F";
-									atlOffset=203.72032;
+									atlOffset=0.0061645508;
 								};
 								class Item12
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={241.06647,18.414215,9600.6787};
-										angles[]={0,4.7782426,0};
+										position[]={14152.729,18.29129,11960.936};
+										angles[]={0,5.3268533,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56785,7 +66195,7 @@ class Mission
 									};
 									id=6088;
 									type="B_AAA_System_01_F";
-									atlOffset=0.00058555603;
+									atlOffset=0.0051250458;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56815,8 +66225,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={243.48645,17.716858,9697.6406};
-										angles[]={0,4.770092,0};
+										position[]={14205.361,17.593933,12042.4};
+										angles[]={0,5.3187027,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56831,7 +66241,7 @@ class Mission
 									};
 									id=6089;
 									type="B_AAA_System_01_F";
-									atlOffset=0.00028800964;
+									atlOffset=0.026808739;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56861,8 +66271,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={269.8985,18.414215,8938.0654};
-										angles[]={0,4.7782426,0};
+										position[]={14485.488,18.290924,12544.71};
+										angles[]={0,5.3268533,0};
 									};
 									side="Empty";
 									flags=4;
@@ -56877,7 +66287,7 @@ class Mission
 									};
 									id=6090;
 									type="B_AAA_System_01_F";
-									atlOffset=0.00021934509;
+									atlOffset=0.017549515;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56907,10 +66317,11 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={272.97278,17.716858,9036.0889};
-										angles[]={0,4.770092,0};
+										position[]={14539.229,17.593567,12626.742};
+										angles[]={0,5.3187027,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 										createAsSimpleObject=1;
@@ -56922,7 +66333,7 @@ class Mission
 									};
 									id=6091;
 									type="B_AAA_System_01_F";
-									atlOffset=1.4921122;
+									atlOffset=0.0069303513;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -56949,7 +66360,7 @@ class Mission
 								};
 							};
 							id=4797;
-							atlOffset=201.54359;
+							atlOffset=73.816193;
 						};
 						class Item4
 						{
@@ -56963,24 +66374,25 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-1570.7535,22.253082,18382.809};
-										angles[]={0,0.9442603,0};
+										position[]={8631.0723,22.25293,24967.775};
+										angles[]={0,2.5591283,0};
 									};
 									side="Empty";
+									flags=4;
 									class Attributes
 									{
 									};
 									id=6092;
 									type="Land_HelipadEmpty_F";
-									atlOffset=208.22308;
+									atlOffset=-50.432053;
 								};
 								class Item1
 								{
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={22.988403,21.918243,9266.5498};
-										angles[]={0,6.210351,0};
+										position[]={14120.806,21.918243,12397.652};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -56988,7 +66400,7 @@ class Mission
 									};
 									id=6093;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.95192;
+									atlOffset=72.633049;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57018,8 +66430,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={108.73059,21.901123,9268.9053};
-										angles[]={0,6.210351,0};
+										position[]={14195.193,21.901123,12354.949};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57027,7 +66439,7 @@ class Mission
 									};
 									id=6094;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.9348;
+									atlOffset=61.195248;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57057,8 +66469,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={105.55676,21.914993,9358.9385};
-										angles[]={0,6.210351,0};
+										position[]={14239.437,21.914993,12433.427};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57066,7 +66478,7 @@ class Mission
 									};
 									id=6095;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.94867;
+									atlOffset=59.094315;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57096,8 +66508,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={21.500122,21.949463,9310.1201};
-										angles[]={0,6.210351,0};
+										position[]={14142.258,21.949463,12435.604};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57135,8 +66547,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={24.859497,21.94693,9174.9229};
-										angles[]={0,6.210351,0};
+										position[]={14074.619,21.94693,12318.498};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57144,7 +66556,7 @@ class Mission
 									};
 									id=6097;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.98061;
+									atlOffset=63.993118;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57174,8 +66586,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={23.082153,21.963959,9266.7217};
-										angles[]={0,6.210351,0};
+										position[]={14120.975,21.963959,12397.754};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57183,7 +66595,7 @@ class Mission
 									};
 									id=6098;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.99763;
+									atlOffset=72.666389;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57213,8 +66625,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={110.47278,21.894669,9224.0068};
-										angles[]={0,6.210351,0};
+										position[]={14173.268,21.894669,12315.73};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57222,7 +66634,7 @@ class Mission
 									};
 									id=6099;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.92834;
+									atlOffset=63.065018;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57252,8 +66664,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={112.22668,21.899109,9179.6846};
-										angles[]={0,6.210351,0};
+										position[]={14151.65,21.899109,12277};
+										angles[]={0,0.47576341,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57261,7 +66673,7 @@ class Mission
 									};
 									id=6100;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.93279;
+									atlOffset=59.604187;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57291,8 +66703,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-7.4370117,21.614746,16909.016};
-										angles[]={0,6.2818151,0};
+										position[]={24744.605,21.614792,13045.624};
+										angles[]={0,1.6134977,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57300,7 +66712,7 @@ class Mission
 									};
 									id=6101;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.38913;
+									atlOffset=208.04089;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57330,8 +66742,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={-7.6707764,21.59967,16818.715};
-										angles[]={0,6.2818151,0};
+										position[]={24654.402,21.599716,13049.833};
+										angles[]={0,1.6134977,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57339,7 +66751,7 @@ class Mission
 									};
 									id=6102;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.36839;
+									atlOffset=210.36578;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57369,8 +66781,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={79.540894,21.678711,17000.145};
-										angles[]={0,6.2818151,0};
+										position[]={24831.813,21.678757,12954.712};
+										angles[]={0,1.6134977,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57378,7 +66790,7 @@ class Mission
 									};
 									id=6103;
 									type="Land_GardenPavement_02_F";
-									atlOffset=207.27905;
+									atlOffset=207.71243;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57408,8 +66820,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={78.269897,21.633179,16907.779};
-										angles[]={0,6.2818151,0};
+										position[]={24739.596,21.633224,12960.051};
+										angles[]={0,1.6134977,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57417,7 +66829,7 @@ class Mission
 									};
 									id=6104;
 									type="Land_GardenPavement_02_F";
-									atlOffset=206.6945;
+									atlOffset=208.43042;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57447,8 +66859,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={78.148804,21.67746,16864.422};
-										angles[]={0,6.2818151,0};
+										position[]={24696.283,21.677505,12962.082};
+										angles[]={0,1.6134977,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57483,7 +66895,7 @@ class Mission
 								};
 							};
 							id=4798;
-							atlOffset=207.68718;
+							atlOffset=212.04308;
 						};
 						class Item5
 						{
@@ -57497,8 +66909,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={98.296997,24.262711,9209.542};
-										angles[]={0,3.9227977,0};
+										position[]={14155.334,24.262711,12309.739};
+										angles[]={0,4.4713993,0};
 									};
 									side="Empty";
 									flags=4;
@@ -57508,7 +66920,7 @@ class Mission
 									};
 									id=6107;
 									type="Land_CampingChair_V1_F";
-									atlOffset=0.056182861;
+									atlOffset=0.0048217773;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57538,8 +66950,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={98.504028,24.726807,9211.4385};
-										angles[]={0,2.9830101,0};
+										position[]={14156.498,24.726807,12311.246};
+										angles[]={0,3.5316186,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57548,7 +66960,7 @@ class Mission
 									};
 									id=6108;
 									type="Land_Laptop_unfolded_F";
-									atlOffset=0.8147068;
+									atlOffset=0.81476784;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57578,8 +66990,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.281372,24.824448,9211.4717};
-										angles[]={0,0.10318518,0};
+										position[]={14157.179,24.824448,12310.871};
+										angles[]={0,0.65178239,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57588,7 +67000,7 @@ class Mission
 									};
 									id=6109;
 									type="Land_PCSet_01_screen_F";
-									atlOffset=0.81373024;
+									atlOffset=0.81384468;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57637,8 +67049,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={96.828247,24.565018,9211.3643};
-										angles[]={0,2.6202276,0};
+										position[]={14155.029,24.565018,12312.059};
+										angles[]={0,3.1688337,0};
 									};
 									side="Empty";
 									flags=4;
@@ -57648,7 +67060,7 @@ class Mission
 									};
 									id=6110;
 									type="Land_TripodScreen_01_dual_v1_F";
-									atlOffset=0.056488037;
+									atlOffset=0.0085792542;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57716,8 +67128,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.834106,24.759247,9211.2705};
-										angles[]={0,0.66054773,0};
+										position[]={14157.547,24.759247,12310.412};
+										angles[]={0,1.2091383,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57726,7 +67138,7 @@ class Mission
 									};
 									id=6111;
 									type="Land_SatellitePhone_F";
-									atlOffset=0.8136692;
+									atlOffset=0.81374931;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57756,8 +67168,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.277466,24.604828,9211.2451};
-										angles[]={0,4.0202317,0};
+										position[]={14157.059,24.604828,12310.681};
+										angles[]={0,4.56884,0};
 									};
 									side="Empty";
 									class Attributes
@@ -57766,7 +67178,7 @@ class Mission
 									};
 									id=6112;
 									type="Land_Tablet_02_F";
-									atlOffset=0.81463051;
+									atlOffset=0.81464577;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57796,8 +67208,8 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={99.17981,24.16687,9211.1475};
-										angles[]={0,0.081064701,0};
+										position[]={14156.926,24.16687,12310.65};
+										angles[]={0,0.62966287,0};
 									};
 									side="Empty";
 									flags=4;
@@ -57806,7 +67218,7 @@ class Mission
 									};
 									id=6113;
 									type="Land_CampingTable_F";
-									atlOffset=0.05645752;
+									atlOffset=0.056625366;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -57833,15 +67245,15 @@ class Mission
 								};
 							};
 							id=618;
-							atlOffset=0.34311485;
+							atlOffset=0.34388542;
 						};
 						class Item6
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={19.158325,24.088379,8689.4023};
-								angles[]={0,4.046453,0};
+								position[]={13816.565,24.088379,11907.191};
+								angles[]={0,4.5950651,0};
 							};
 							side="Empty";
 							class Attributes
@@ -57849,15 +67261,15 @@ class Mission
 							};
 							id=5961;
 							type="Land_HelipadEmpty_F";
-							atlOffset=210.05838;
+							atlOffset=50.264862;
 						};
 						class Item7
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={63.650513,0.12257385,9318.8486};
-								angles[]={0,3.1006114,0};
+								position[]={14182.771,0.12257385,12421.073};
+								angles[]={0,3.6492214,0};
 							};
 							side="Empty";
 							class Attributes
@@ -57866,15 +67278,15 @@ class Mission
 							};
 							id=5962;
 							type="Land_Carrier_01_base_F";
-							atlOffset=186.09258;
+							atlOffset=50.922096;
 						};
 						class Item8
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={242.24817,0.12289429,9650.4658};
-								angles[]={0,3.1741071,0};
+								position[]={14179.703,-3.0517578e-005,12002.798};
+								angles[]={0,3.7227175,0};
 							};
 							side="Empty";
 							class Attributes
@@ -57882,7 +67294,7 @@ class Mission
 							};
 							id=5963;
 							type="Land_Destroyer_01_base_F";
-							atlOffset=186.0929;
+							atlOffset=56.106991;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -57931,8 +67343,8 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={272.0177,0.1232605,8988.1748};
-								angles[]={0,3.1741071,0};
+								position[]={14513.428,-3.0517578e-005,12586.357};
+								angles[]={0,3.7227175,0};
 							};
 							side="Empty";
 							class Attributes
@@ -57940,7 +67352,7 @@ class Mission
 							};
 							id=5964;
 							type="Land_Destroyer_01_base_F";
-							atlOffset=186.09326;
+							atlOffset=51.756535;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -57989,17 +67401,18 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={102.98846,24.042297,9347.0361};
-								angles[]={0,1.4964533,0};
+								position[]={14231.037,24.042297,12424.61};
+								angles[]={0,2.0450397,0};
 							};
 							side="Empty";
+							flags=4;
 							class Attributes
 							{
 								name="oppas_kiste";
 							};
 							id=6106;
 							type="Box_NATO_Uniforms_F";
-							atlOffset=209.63077;
+							atlOffset=0.0038776398;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -58043,11 +67456,1931 @@ class Mission
 								nAttributes=2;
 							};
 						};
+						class Item11
+						{
+							dataType="Layer";
+							name="CSAT Marine Basen";
+							class Entities
+							{
+								items=7;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={14461.51,9.0890951,12529.182};
+										angles[]={0,1.103855,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+										disableSimulation=1;
+										aiRadarUsage=28025824;
+									};
+									id=5329;
+									type="Land_TyreBarrier_01_F";
+									atlOffset=58.179794;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={14461.606,9.3335133,12529.135};
+										angles[]={0,4.8613567,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										skill=0.60000002;
+										init="call{this setVariable [""opt_warehouse_data"", [""Marine-Ausrüstung"", ""sea"", east]]}";
+									};
+									id=5330;
+									type="Land_InfoStand_V1_F";
+									atlOffset=0.0009021759;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="ObjectTextureCustom0";
+											expression="_this setObjectTextureGlobal [0,_value]";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="opt_core\bilder\csat_marine_ausruestung.paa";
+												};
+											};
+										};
+										class Attribute1
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=2;
+									};
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={14450.881,-0.12329102,12533.135};
+										angles[]={0,2.0737622,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+										skill=0.60000002;
+									};
+									id=5331;
+									type="Land_HelipadCircle_F";
+									atlOffset=50.505436;
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={7158.127,-19.035769,10937.408};
+										angles[]={0,5.930788,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5332;
+									type="Land_PierWooden_02_16m_F";
+									atlOffset=-1.8921239;
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={8370.7148,42.61998,25288.645};
+										angles[]={0,1.8048995,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5333;
+									type="Land_PierWooden_02_16m_F";
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={7161.8618,-16.906258,10926.599};
+										angles[]={0,4.3552275,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5334;
+									type="Land_PierWooden_02_hut_F";
+									atlOffset=-1.127049;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={8359.6406,43.210129,25291.521};
+										angles[]={0,0.22928907,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5335;
+									type="Land_PierWooden_02_hut_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="allowDamage";
+											expression="_this allowdamage _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"BOOL"
+														};
+													};
+													value=0;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+							};
+							id=3551;
+							atlOffset=-19.257252;
+						};
+						class Item12
+						{
+							dataType="Layer";
+							name="C_basismodul";
+							class Entities
+							{
+								items=8;
+								class Item0
+								{
+									dataType="Layer";
+									name="C_sicherh_zonen";
+									class Entities
+									{
+										items=2;
+										class Item0
+										{
+											dataType="Trigger";
+											position[]={14062.367,-132.17668,12252.588};
+											angle=1.5472684;
+											class Attributes
+											{
+												text="NATO Todeszone";
+												condition="vehicle player in thisList";
+												onActivation="{player setDamage 1} foreach thisList; systemChat ""Ein NATO Spieler wurde auf Grund des Betretens der feindlichen Basis automatisch getötet!""";
+												sizeA=2000;
+												sizeB=2000;
+												timeout[]={10,10,10};
+												interuptable=1;
+												repeatable=1;
+												activationBy="WEST";
+											};
+											id=5293;
+											type="EmptyDetector";
+											atlOffset=-97.46743;
+										};
+										class Item1
+										{
+											dataType="Marker";
+											position[]={14066.103,-0.047168732,12249.418};
+											name="NATO_T_Zone";
+											markerType="ELLIPSE";
+											type="ellipse";
+											colorName="ColorEAST";
+											alpha=0.16960363;
+											fillName="SolidFull";
+											a=2000;
+											b=2000;
+											id=8177;
+											atlOffset=35.64629;
+										};
+									};
+									id=719;
+									atlOffset=-30.912251;
+								};
+								class Item1
+								{
+									dataType="Layer";
+									name="C_auslöser";
+									class Entities
+									{
+										items=8;
+										class Item0
+										{
+											dataType="Trigger";
+											position[]={8412.4697,103.16354,25160.094};
+											angle=4.036458;
+											class Attributes
+											{
+												name="csat_trigger_beam_4";
+												text="Trigger für Beam-Dialog";
+												condition="call{this && vehicle player in thislist}";
+												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=0;
+												sizeB=0;
+												sizeC=0;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5150;
+											type="EmptyDetectorAreaR50";
+											atlOffset=-1.0339966;
+										};
+										class Item1
+										{
+											dataType="Trigger";
+											position[]={8413.4805,102.24931,25167.217};
+											angle=4.036458;
+											class Attributes
+											{
+												name="csat_trigger_beam_6";
+												text="Trigger für Beam-Dialog";
+												condition="call{this && vehicle player in thislist}";
+												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=0;
+												sizeB=0;
+												sizeC=0;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5151;
+											type="EmptyDetectorAreaR50";
+										};
+										class Item2
+										{
+											dataType="Trigger";
+											position[]={8412.5889,102.28828,25164.184};
+											angle=4.036458;
+											class Attributes
+											{
+												name="csat_trigger_beam_5";
+												text="Trigger für Beam-Dialog";
+												condition="call{this && vehicle player in thislist}";
+												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=0;
+												sizeB=0;
+												sizeC=0;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5152;
+											type="EmptyDetectorAreaR50";
+											atlOffset=-0.80500031;
+										};
+										class Item3
+										{
+											dataType="Trigger";
+											position[]={14133.701,23.664673,12259.561};
+											angle=0.521855;
+											class Attributes
+											{
+												name="csat_trigger_beam_3";
+												text="Trigger für Beam-Dialog";
+												condition="call{this && vehicle player in thislist}";
+												onActivation="call{[""Beam-System"", ""Beam-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=4.3943043;
+												sizeB=4.939353;
+												sizeC=3.1158428;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5295;
+											type="EmptyDetectorAreaR50";
+											atlOffset=66.203186;
+										};
+										class Item4
+										{
+											dataType="Trigger";
+											position[]={14144.358,23.651001,12283.813};
+											angle=0.49293602;
+											class Attributes
+											{
+												name="csat_trigger_Waffenwechsel2";
+												text="Trigger für Waffenwechsel-Dialog";
+												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
+												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=4.447;
+												sizeB=4.4549999;
+												sizeC=2.4820001;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5296;
+											type="EmptyDetectorAreaR50";
+											atlOffset=60.787033;
+										};
+										class Item5
+										{
+											dataType="Trigger";
+											position[]={14216.432,20.181885,12351.07};
+											angle=0.54131657;
+											class Attributes
+											{
+												name="opt_warehouse_garbage_collector_6";
+												text="Löschbereich für Wracks Landebahn";
+												sizeA=200;
+												sizeB=500;
+												repeatable=1;
+												activationBy="ANY";
+												isRectangle=1;
+											};
+											id=5297;
+											type="EmptyDetectorAreaR50";
+											atlOffset=59.119835;
+										};
+										class Item6
+										{
+											dataType="Trigger";
+											position[]={14192.738,23.388992,12426.375};
+											angle=3.6433911;
+											class Attributes
+											{
+												name="csat_trigger_Waffenwechsel1";
+												text="Trigger für Waffenwechsel-Dialog";
+												condition="call{opt_waffenwechsel_on and this && vehicle player in thislist && (driver vehicle player) == player}";
+												onActivation="call{[""Waffenwechsel-System"", ""Waffenwechsel-Dialog kann geöffnet werden"", ""blue""] call opt_gui_fnc_message;}";
+												sizeA=4;
+												sizeB=4.4679999;
+												sizeC=4.7280002;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5298;
+											type="EmptyDetectorAreaR50";
+											atlOffset=71.161224;
+										};
+										class Item7
+										{
+											dataType="Trigger";
+											position[]={14192.78,23.661713,12426.415};
+											angle=5.2299371;
+											class Attributes
+											{
+												name="trg_csat_repair_1";
+												text="Auslöser für Rep-Script";
+												condition="call{vehicle player in thislist && !isNull (objectParent player) && driver (vehicle player) == player && speed (vehicle player) < 0.1}";
+												onActivation="call{nul = [true] spawn opt_mission_fnc_repairSystem;}";
+												onDeactivation="nul = [false] spawn opt_mission_fnc_repairSystem;";
+												sizeA=5.1464071;
+												sizeB=4.7551084;
+												sizeC=6.6230001;
+												repeatable=1;
+												activationBy="EAST";
+												isRectangle=1;
+											};
+											id=5299;
+											type="EmptyDetectorArea10x10";
+											atlOffset=0.00073623657;
+										};
+									};
+									id=789;
+									atlOffset=31.918823;
+								};
+								class Item2
+								{
+									dataType="Layer";
+									name="C_basis";
+									class Entities
+									{
+										items=7;
+										class Item0
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14171.144,23.651016,12342.832};
+												angles[]={0,5.2330303,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5300;
+											type="Land_HelipadCircle_F";
+											atlOffset=64.794708;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item1
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14216.63,23.661163,12415.633};
+												angles[]={0,5.218154,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5301;
+											type="Land_HelipadCircle_F";
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item2
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14095.047,23.651016,12331.35};
+												angles[]={0,2.0845721,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5302;
+											type="Land_HelipadCircle_F";
+											atlOffset=67.538383;
+										};
+										class Item3
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14153.141,27.627821,12323.781};
+												angles[]={0,3.8510878,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+												init="call{this allowDamage false; [this, west] spawn opt_mhq_fnc_init;  this addAction [""<t color='#00ff00' size='1.25'>Beam-System benutzen</t>"", {[] call opt_beam_fnc_openDialog}, false, 5, false, true, """"]; }";
+												name="homeflag_east";
+											};
+											id=5303;
+											type="Flag_CSAT_F";
+											atlOffset=63.210693;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item4
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14156.877,24.032913,12326.969};
+												angles[]={0,1.3295405,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this addEventHandler [""ContainerClosed"", {params [""_container""]; clearWeaponCargoGlobal _container; clearMagazineCargoGlobal _container; clearItemCargoGlobal _container; clearBackpackCargoGlobal _container;  }]; this allowDamage false;}";
+											};
+											id=5304;
+											type="Box_NATO_Uniforms_F";
+											atlOffset=0.068229675;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="ammoBox";
+													expression="[_this,_value] call bis_fnc_initAmmoBox;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"STRING"
+																};
+															};
+															value="[[[[],[]],[[],[]],[[],[]],[[],[]]],true]";
+														};
+													};
+												};
+												class Attribute1
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=2;
+											};
+										};
+										class Item5
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14192.076,23.651016,12376.014};
+												angles[]={0,5.2173729,0};
+											};
+											side="Empty";
+											class Attributes
+											{
+												skill=0.60000002;
+											};
+											id=5305;
+											type="Land_HelipadCircle_F";
+											atlOffset=61.759407;
+										};
+										class Item6
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14154.039,24.476303,12326.785};
+												angles[]={0,2.0410869,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												health=0.6761747;
+											};
+											id=5306;
+											type="OPT_O_CargoNet_01_ammo_F";
+											atlOffset=0.14678383;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="ammoBox";
+													expression="[_this,_value] call bis_fnc_initAmmoBox;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"STRING"
+																};
+															};
+															value="[[[[""OPT_hgun_Rook40_F""],[70]],[[],[]],[[""optic_ACO_grn_smg"",""optic_Aco_smg"",""optic_Holosight_smg_blk_F"",""optic_ACO_grn"",""optic_Aco"",""optic_Holosight_blk_F"",""optic_Arco_blk_F"",""optic_Hamr"",""optic_MRCO"",""optic_ERCO_blk_F"",""acc_flashlight"",""acc_pointer_IR"",""ACE_DefusalKit"",""ACE_wirecutter"",""NVGoggles_OPFOR""],[50,50,50,50,50,50,50,50,50,50,50,50,20,10,70]],[[""B_FieldPack_ocamo"",""TFAR_mr3000"",""ACE_TacticalLadder_Pack"",""B_Parachute""],[25,25,10,60]]],false]";
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+									};
+									id=797;
+									atlOffset=0.082077026;
+								};
+								class Item3
+								{
+									dataType="Layer";
+									name="C_schilder";
+									id=820;
+									atlOffset=185.97;
+								};
+								class Item4
+								{
+									dataType="Layer";
+									name="C_modelle";
+									class Entities
+									{
+										items=5;
+										class Item0
+										{
+											dataType="Group";
+											side="West";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={14148.196,23.652958,12313.541};
+														angles[]={0,4.2567339,0};
+													};
+													side="West";
+													flags=7;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5308;
+													type="OPT_NATO_Besatzungsmitglied";
+													atlOffset=0.00049972534;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=1.04;
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=4;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5307;
+											atlOffset=0.00049972534;
+										};
+										class Item1
+										{
+											dataType="Group";
+											side="West";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={14149.955,23.652958,12317.134};
+														angles[]={0,4.5556984,0};
+													};
+													side="West";
+													flags=6;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5310;
+													type="OPT_NATO_Scharfschuetze";
+													atlOffset=0.00049972534;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male05ENG";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=1.04;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5309;
+											atlOffset=0.00049972534;
+										};
+										class Item2
+										{
+											dataType="Group";
+											side="West";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={14149.264,23.652958,12315.716};
+														angles[]={0,5.5193529,0};
+													};
+													side="West";
+													flags=6;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5312;
+													type="OPT_NATO_Grenadier";
+													atlOffset=0.00049972534;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=1.04;
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=4;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5311;
+											atlOffset=0.00049972534;
+										};
+										class Item3
+										{
+											dataType="Group";
+											side="West";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={14147.51,23.652958,12311.933};
+														angles[]={0,5.5193529,0};
+													};
+													side="West";
+													flags=6;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+													};
+													id=5314;
+													type="OPT_NATO_Pilot";
+													atlOffset=0.00049972534;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="speaker";
+															expression="_this setspeaker _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Male08ENG";
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=1.04;
+																};
+															};
+														};
+														class Attribute4
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=5;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5313;
+											atlOffset=0.00049972534;
+										};
+										class Item4
+										{
+											dataType="Group";
+											side="West";
+											class Entities
+											{
+												items=1;
+												class Item0
+												{
+													dataType="Object";
+													class PositionInfo
+													{
+														position[]={14148.633,23.652958,12314.578};
+														angles[]={0,4.9844398,0};
+													};
+													side="West";
+													flags=7;
+													class Attributes
+													{
+														disableSimulation=1;
+														ignoreByDynSimulGrid=1;
+														stance="Middle";
+														class Inventory
+														{
+															map="ItemMap";
+															compass="ItemCompass";
+															watch="ItemWatch";
+															radio="tf_anprc152";
+															gps="ItemGPS";
+															headgear="H_StrawHat_dark";
+														};
+													};
+													id=5316;
+													type="OPT_NATO_Besatzungsmitglied";
+													atlOffset=0.00049972534;
+													class CustomAttributes
+													{
+														class Attribute0
+														{
+															property="allowDamage";
+															expression="_this allowdamage _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute1
+														{
+															property="enableStamina";
+															expression="_this enablestamina _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"BOOL"
+																		};
+																	};
+																	value=0;
+																};
+															};
+														};
+														class Attribute2
+														{
+															property="pitch";
+															expression="_this setpitch _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"SCALAR"
+																		};
+																	};
+																	value=1.04;
+																};
+															};
+														};
+														class Attribute3
+														{
+															property="face";
+															expression="_this setface _value;";
+															class Value
+															{
+																class data
+																{
+																	class type
+																	{
+																		type[]=
+																		{
+																			"STRING"
+																		};
+																	};
+																	value="Custom";
+																};
+															};
+														};
+														nAttributes=4;
+													};
+												};
+											};
+											class Attributes
+											{
+												behaviour="CARELESS";
+												speedMode="LIMITED";
+											};
+											id=5315;
+											atlOffset=0.00049972534;
+										};
+									};
+									id=907;
+									atlOffset=0.00049972534;
+								};
+								class Item5
+								{
+									dataType="Layer";
+									name="C_bestell_laptops";
+									class Entities
+									{
+										items=5;
+										class Item0
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14232.011,24.629776,12427.373};
+												angles[]={0,5.9802008,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Luftwaffe"", ""choppers"", east]]}";
+												disableSimulation=1;
+											};
+											id=5317;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=0.0012950897;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item1
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14172.189,24.620575,12323.619};
+												angles[]={0,5.180994,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Panzer"", ""armored"", east]]}";
+												disableSimulation=1;
+											};
+											id=5318;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=0.027763367;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item2
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14194.508,24.620392,12359.738};
+												angles[]={0,4.725666,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Nachschub"", ""supplies"", east]]}";
+												disableSimulation=1;
+											};
+											id=5319;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=0.027833939;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item3
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14096.852,24.620239,12350.887};
+												angles[]={0,0.41757312,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Fahrzeuge"", ""vehicles"", east]]}";
+												disableSimulation=1;
+											};
+											id=5320;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=0.01640892;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item4
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14252.149,24.623764,12464.898};
+												angles[]={0,6.0441046,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+												init="call{this setVariable [""opt_warehouse_data"", [""Verkaufen"", ""sell"", east]]}";
+												disableSimulation=1;
+											};
+											id=5321;
+											type="Land_Laptop_unfolded_F";
+											atlOffset=0.012289047;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+									};
+									id=901;
+									atlOffset=0.81977654;
+								};
+								class Item6
+								{
+									dataType="Layer";
+									name="C_bestell_tische";
+									class Entities
+									{
+										items=6;
+										class Item0
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14231.965,24.066391,12427.205};
+												angles[]={0,3.0784302,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5322;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.0045681;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item1
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14172.166,24.056702,12323.544};
+												angles[]={0,1.814904,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5323;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.072568893;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item2
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14194.541,24.05658,12359.656};
+												angles[]={0,1.0144882,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5324;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.072788239;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item3
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14096.781,24.056458,12350.797};
+												angles[]={0,3.7981002,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5325;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.043088913;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item4
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={14252.178,24.057465,12464.729};
+												angles[]={0,3.1420329,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5326;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.025606155;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+										class Item5
+										{
+											dataType="Object";
+											class PositionInfo
+											{
+												position[]={24621.184,23.773361,13048.081};
+												angles[]={0,1.1828723,0};
+											};
+											side="Empty";
+											flags=4;
+											class Attributes
+											{
+											};
+											id=5327;
+											type="Land_CampingTable_small_F";
+											atlOffset=0.0002822876;
+											class CustomAttributes
+											{
+												class Attribute0
+												{
+													property="allowDamage";
+													expression="_this allowdamage _value;";
+													class Value
+													{
+														class data
+														{
+															class type
+															{
+																type[]=
+																{
+																	"BOOL"
+																};
+															};
+															value=0;
+														};
+													};
+												};
+												nAttributes=1;
+											};
+										};
+									};
+									id=918;
+									atlOffset=-64.99057;
+								};
+								class Item7
+								{
+									dataType="Marker";
+									position[]={14142.094,857.22894,12318.375};
+									name="respawn_east";
+									type="respawn_unknown";
+									colorName="ColorRed";
+									angle=33.202126;
+									id=5328;
+									atlOffset=833.57794;
+								};
+							};
+							id=617;
+							atlOffset=507.08893;
+						};
+						class Item13
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={8462.1914,101.42706,25164.809};
+								angles[]={0.23806481,5.3488054,0.1141679};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+								name="OPT_radar_containerEast";
+								presenceCondition="OPT_radar_on";
+							};
+							id=2741;
+							type="OPT_Land_Pod_Heli_Transport_04_repair_radar_F";
+							atlOffset=-0.11037445;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="ammoBox";
+									expression="[_this,_value] call bis_fnc_initAmmoBox;";
+									class Value
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+										};
+									};
+								};
+								nAttributes=1;
+							};
+						};
 					};
 					id=4162;
-					atlOffset=199.2576;
+					atlOffset=16.96196;
 				};
-				class Item11
+				class Item9
 				{
 					dataType="Layer";
 					name="1_fahnenpositionen";
@@ -58489,7 +69822,7 @@ class Mission
 						class Item32
 						{
 							dataType="Marker";
-							position[]={13591.078,42.521999,12188.469};
+							position[]={13707.197,42.521832,12315.568};
 							name="f33";
 							markerType="ELLIPSE";
 							type="ellipse";
@@ -58498,7 +69831,7 @@ class Mission
 							b=10;
 							angle=4.6759987;
 							id=6262;
-							atlOffset=26.57095;
+							atlOffset=28.685987;
 						};
 						class Item33
 						{
@@ -58599,7 +69932,7 @@ class Mission
 						class Item40
 						{
 							dataType="Marker";
-							position[]={19422,-185.97,7972};
+							position[]={19398.398,-185.97,7951.269};
 							name="f41";
 							markerType="ELLIPSE";
 							type="ellipse";
@@ -58607,7 +69940,7 @@ class Mission
 							a=10;
 							b=10;
 							id=6273;
-							atlOffset=-235.67868;
+							atlOffset=-236.66795;
 						};
 						class Item41
 						{
@@ -58886,52 +70219,1015 @@ class Mission
 					id=6118;
 					atlOffset=-405.87399;
 				};
-			};
-			id=4139;
-			atlOffset=-161.33293;
-		};
-		class Item1
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8421.3574,112.86955,25113.723};
-				angles[]={0,4.4505897,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-				init="call{[this, 8] call ace_cargo_fnc_setSize;[this, true, [0, 3, 1], 0] call ace_dragging_fnc_setCarryable;[this, true, [0, 2, 0], 0] call ace_dragging_fnc_setDraggable;}";
-			};
-			id=5226;
-			type="OPT_B_Slingload_01_Medevac_F";
-			atlOffset=-0.0011138916;
-			class CustomAttributes
-			{
-				class Attribute0
+				class Item10
 				{
-					property="ammoBox";
-					expression="[_this,_value] call bis_fnc_initAmmoBox;";
-					class Value
+					dataType="Layer";
+					name="beampunkte";
+					state=3;
+					class Entities
 					{
-						class data
+						items=62;
+						class Item0
 						{
-							class type
+							dataType="Object";
+							class PositionInfo
 							{
-								type[]=
-								{
-									"STRING"
-								};
+								position[]={4925.6323,341.19653,21895.656};
 							};
-							value="[[[[""launch_NLAW_F"",""arifle_MX_F"",""arifle_MX_SW_F""],[2,4,2]],[[""30Rnd_65x39_caseless_mag"",""16Rnd_9x21_Mag"",""30Rnd_45ACP_Mag_SMG_01"",""20Rnd_762x51_Mag"",""100Rnd_65x39_caseless_mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_green"",""Laserbatteries"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[48,12,12,12,12,12,4,4,12,4,12,12,4,4,4,4]],[[""Laserdesignator"",""FirstAidKit"",""acc_flashlight""],[2,20,4]],[[""B_Kitbag_mcamo""],[4]]],false]";
+							side="Empty";
+							class Attributes
+							{
+								name="b1";
+							};
+							id=6367;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0014038086;
+						};
+						class Item1
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={4582.2017,299.6069,21385.365};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_1";
+							};
+							id=6370;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010986328;
+						};
+						class Item2
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={9684.7617,3.5207906,22269.395};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_10";
+							};
+							id=6379;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011410713;
+						};
+						class Item3
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={8532.0986,68.093964,20879.943};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_11";
+							};
+							id=6380;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.001335144;
+						};
+						class Item4
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={9410.1563,118.25887,20300.502};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_12";
+							};
+							id=6381;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010910034;
+						};
+						class Item5
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={10405.196,120.67762,19023.145};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_13";
+							};
+							id=6382;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010528564;
+						};
+						class Item6
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={7533.3193,134.73981,18346.297};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_14";
+							};
+							id=6383;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0020904541;
+						};
+						class Item7
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={7111.4897,111.96675,16438.803};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_15";
+							};
+							id=6384;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011062622;
+						};
+						class Item8
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={9196.6797,120.77501,15821.593};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_16";
+							};
+							id=6385;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011062622;
+						};
+						class Item9
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={9301.5342,30.298265,13664.528};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_17";
+							};
+							id=6386;
+							type="Land_HelipadEmpty_F";
+							atlOffset=8.2015991e-005;
+						};
+						class Item10
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={9468.4805,26.262537,8236.5488};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_18";
+							};
+							id=6387;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item11
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={12318.005,20.195953,22856.318};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_19";
+							};
+							id=6388;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010585785;
+						};
+						class Item12
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={4910.3472,197.1022,19458.254};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_2";
+							};
+							id=6371;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011138916;
+						};
+						class Item13
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={13013.089,32.230129,19448.695};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_20";
+							};
+							id=6389;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011062622;
+						};
+						class Item14
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={12672.666,34.210361,16390.48};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_21";
+							};
+							id=6390;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item15
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={13248.13,13.200888,14947.823};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_22";
+							};
+							id=6391;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.00086307526;
+						};
+						class Item16
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={12151.891,9.668313,14330.698};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_23";
+							};
+							id=6392;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011320114;
+						};
+						class Item17
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={11105.64,19.684849,13325.393};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_24";
+							};
+							id=6393;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item18
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={10675.173,16.757935,12266.578};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_25";
+							};
+							id=6394;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item19
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={10819.854,6.4413772,10859.053};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_26";
+							};
+							id=6395;
+							type="Land_HelipadEmpty_F";
+							atlOffset=7.1048737e-005;
+						};
+						class Item20
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={11562.51,77.303802,7045.9185};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_27";
+							};
+							id=6396;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011062622;
+						};
+						class Item21
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={14266.871,43.789253,22215.367};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_28";
+							};
+							id=6397;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item22
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={14716.515,46.701706,20735.465};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_29";
+							};
+							id=6398;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item23
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={3360.3782,67.56945,18310.93};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_3";
+							};
+							id=6372;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.00054931641;
+						};
+						class Item24
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={14320.399,36.900391,18909.221};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_30";
+							};
+							id=6399;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item25
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={14937.858,17.528454,17153.338};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_31";
+							};
+							id=6400;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.001241684;
+						};
+						class Item26
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={13589.743,16.363777,12166.921};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_32";
+							};
+							id=6401;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011081696;
+						};
+						class Item27
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={11908.478,15.18861,9707.3877};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_33";
+							};
+							id=6402;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0013866425;
+						};
+						class Item28
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={16587.895,35.317459,19002.33};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_34";
+							};
+							id=6403;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item29
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={16451.031,24.131969,17237.797};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_35";
+							};
+							id=6404;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.00080680847;
+						};
+						class Item30
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={16681.539,18.231377,16143.08};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_36";
+							};
+							id=6405;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item31
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={16703.346,10.311413,13522.601};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_37";
+							};
+							id=6406;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item32
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={16611.455,13.550769,12640.338};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_38";
+							};
+							id=6407;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item33
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={17769.818,41.113083,10566.192};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_39";
+							};
+							id=6408;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item34
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={5410.8721,76.737549,17909.359};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_4";
+							};
+							id=6373;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011138916;
+						};
+						class Item35
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={19406.996,50.685932,7955.5903};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_40";
+							};
+							id=6409;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0013160706;
+						};
+						class Item36
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={18943.773,28.606129,16660.947};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_41";
+							};
+							id=6410;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.00097465515;
+						};
+						class Item37
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={18420.234,49.431179,15511.571};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_42";
+							};
+							id=6411;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item38
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={18147.764,25.077732,15225.152};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_43";
+							};
+							id=6412;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010070801;
+						};
+						class Item39
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={19702.965,89.270676,12960.619};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_44";
+							};
+							id=6413;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011062622;
+						};
+						class Item40
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20155.959,41.908695,11718.664};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_45";
+							};
+							id=6414;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0012359619;
+						};
+						class Item41
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20555.693,39.293385,9022.5293};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_46";
+							};
+							id=6415;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item42
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20907.025,34.035168,6664.6289};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_47";
+							};
+							id=6416;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item43
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20092.324,17.621887,20026.533};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_48";
+							};
+							id=6417;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010795593;
+						};
+						class Item44
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20958.469,15.521555,19261.99};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_49";
+							};
+							id=6418;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.001039505;
+						};
+						class Item45
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={6181.8838,43.000999,16256.253};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_5";
+							};
+							id=6374;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.00099945068;
+						};
+						class Item46
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={50940,-185.879,17008};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_50";
+							};
+							id=6419;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010070801;
+						};
+						class Item47
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={21373.045,18.855602,16254.126};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_51";
+							};
+							id=6420;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.00089836121;
+						};
+						class Item48
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={21185.318,2.11974,14617.707};
+								angles[]={6.2738504,0,6.2658529};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_52";
+							};
+							id=6421;
+							type="Land_HelipadEmpty_F";
+						};
+						class Item49
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={22010.072,29.125452,21064.441};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_53";
+							};
+							id=6422;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010356903;
+						};
+						class Item50
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={22283.615,14.165822,18499.398};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_54";
+							};
+							id=6423;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item51
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={22599.842,13.634861,16825.371};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_55";
+							};
+							id=6424;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item52
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={23371.816,3.9426758,24183.539};
+								angles[]={0,3.2299411,0};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_56";
+							};
+							id=6425;
+							type="Land_HelipadEmpty_F";
+						};
+						class Item53
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={23466.807,90.535362,21137.943};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_57";
+							};
+							id=6426;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011367798;
+						};
+						class Item54
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={24755.986,3.8023796,19153.188};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_58";
+							};
+							id=6427;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0013420582;
+						};
+						class Item55
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={26731.115,20.005753,24638.008};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_59";
+							};
+							id=6428;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item56
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={4267.708,28.040495,13902.733};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_6";
+							};
+							id=6375;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0010910034;
+						};
+						class Item57
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={26989.885,20.367672,23206.453};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_60";
+							};
+							id=6429;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item58
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={25420.861,10.028322,20338.611};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_61";
+							};
+							id=6430;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011100769;
+						};
+						class Item59
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={3723.6956,18.555311,12999.2};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_7";
+							};
+							id=6376;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.001127243;
+						};
+						class Item60
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={5940.9346,101.7437,12461.137};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_8";
+							};
+							id=6377;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011367798;
+						};
+						class Item61
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={7233.4165,4.3041649,11030.594};
+							};
+							side="Empty";
+							class Attributes
+							{
+								name="b1_9";
+							};
+							id=6378;
+							type="Land_HelipadEmpty_F";
+							atlOffset=0.0011081696;
 						};
 					};
+					id=6500;
+					atlOffset=-13.721222;
 				};
-				nAttributes=1;
 			};
+			id=4139;
+			atlOffset=-4.1996651;
 		};
-		class Item2
+		class Item1
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -59041,7 +71337,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item3
+		class Item2
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -59152,7 +71448,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item4
+		class Item3
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -59262,7 +71558,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item5
+		class Item4
 		{
 			dataType="Group";
 			side="East";
@@ -59274,8 +71570,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={32.190681,23.280216,9249.6396};
-						angles[]={0,1.4814354,0};
+						position[]={14119.81,23.628422,12377.836};
+						angles[]={0,2.0300219,0};
 					};
 					side="East";
 					flags=3;
@@ -59360,7 +71656,7 @@ class Mission
 					};
 					id=6311;
 					type="OPT_CSAT_Gruppenfuehrer";
-					atlOffset=209.24878;
+					atlOffset=75.863556;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -59409,8 +71705,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={29.496681,23.280216,9250.9258};
-						angles[]={0,1.4249216,0};
+						position[]={14118.181,23.628422,12380.342};
+						angles[]={0,1.9735076,0};
 					};
 					side="East";
 					flags=1;
@@ -59496,7 +71792,7 @@ class Mission
 					};
 					id=6312;
 					type="OPT_CSAT_LMG_Schuetze";
-					atlOffset=209.24878;
+					atlOffset=76.298065;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -59545,8 +71841,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={29.863688,23.280216,9249.3486};
-						angles[]={0,1.4666874,0};
+						position[]={14117.672,23.628422,12378.803};
+						angles[]={0,2.0152738,0};
 					};
 					side="East";
 					flags=1;
@@ -59634,7 +71930,7 @@ class Mission
 					};
 					id=6313;
 					type="OPT_CSAT_Sanitaeter";
-					atlOffset=209.24878;
+					atlOffset=76.21019;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -59683,8 +71979,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={30.200686,23.280216,9247.5654};
-						angles[]={0,1.4621147,0};
+						position[]={14117.028,23.628422,12377.104};
+						angles[]={0,2.0107009,0};
 					};
 					side="East";
 					flags=1;
@@ -59772,7 +72068,7 @@ class Mission
 					};
 					id=6314;
 					type="OPT_CSAT_Sanitaeter";
-					atlOffset=209.24878;
+					atlOffset=75.486702;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -59821,11 +72117,11 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={27.095688,23.668369,9250.7383};
-						angles[]={0,1.4547144,0};
+						position[]={14116.034,24.016575,12381.434};
+						angles[]={0,2.0033009,0};
 					};
 					side="East";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Panther""];}";
@@ -59926,7 +72222,7 @@ class Mission
 					};
 					id=6315;
 					type="OPT_CSAT_Grenadier";
-					atlOffset=0.00029945374;
+					atlOffset=0.3486557;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -59975,8 +72271,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={27.602684,23.668369,9249.0723};
-						angles[]={0,1.4354635,0};
+						position[]={14115.599,23.845201,12379.746};
+						angles[]={0,1.9840496,0};
 					};
 					side="East";
 					flags=5;
@@ -60050,7 +72346,7 @@ class Mission
 					};
 					id=6316;
 					type="OPT_CSAT_Soldat";
-					atlOffset=0.00055122375;
+					atlOffset=0.17753601;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60099,11 +72395,10 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={27.828682,23.668369,9247.2158};
-						angles[]={0,1.5604116,6.2826972};
+						position[]={14114.822,24.016575,12378.043};
+						angles[]={6.2829447,2.1089981,6.2827773};
 					};
 					side="East";
-					flags=4;
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Panther""];}";
@@ -60214,7 +72509,7 @@ class Mission
 					};
 					id=6317;
 					type="OPT_CSAT_Sprengmeister";
-					atlOffset=0.00066947937;
+					atlOffset=0.34902573;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60263,11 +72558,11 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={25.427681,23.668369,9247.1035};
-						angles[]={0,1.4902843,0};
+						position[]={14112.716,23.729727,12379.201};
+						angles[]={0,2.0388708,0};
 					};
 					side="East";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Panther""];}";
@@ -60338,7 +72633,7 @@ class Mission
 					};
 					id=6318;
 					type="OPT_CSAT_Soldat";
-					atlOffset=209.63693;
+					atlOffset=0.061029434;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60387,11 +72682,11 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={24.986687,23.668369,9248.8545};
-						angles[]={0,1.5607607,0};
+						position[]={14113.254,23.716362,12380.924};
+						angles[]={0,2.1093471,0};
 					};
 					side="East";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Panther""];}";
@@ -60467,7 +72762,7 @@ class Mission
 					};
 					id=6319;
 					type="OPT_CSAT_Beobachter";
-					atlOffset=209.63693;
+					atlOffset=0.04744339;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60516,15 +72811,15 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={24.697685,23.668369,9250.4424};
-						angles[]={0,1.4434745,6.2761011};
+						position[]={14114.008,23.628452,12382.398};
+						angles[]={0,2.0223131,0};
 					};
 					side="East";
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Panther""];}";
-						name="csat_lat";
-						description="Leichter AT-Schütze@Panther";
+						name="csat_MAAWS_1";
+						description="Light AT-Schütze@Panther";
 						isPlayable=1;
 						class Inventory
 						{
@@ -60538,15 +72833,6 @@ class Mission
 								{
 									name="30Rnd_580x42_Mag_F";
 									ammoLeft=30;
-								};
-							};
-							class secondaryWeapon
-							{
-								name="OPT_launch_RPG32_F";
-								class primaryMuzzleMag
-								{
-									name="RPG32_F";
-									ammoLeft=1;
 								};
 							};
 							class binocular
@@ -60593,16 +72879,6 @@ class Mission
 							{
 								typeName="B_ViperHarness_hex_F";
 								isBackpack=1;
-								class MagazineCargo
-								{
-									items=1;
-									class Item0
-									{
-										name="RPG32_F";
-										count=1;
-										ammoLeft=1;
-									};
-								};
 							};
 							map="ItemMap";
 							compass="ItemCompass";
@@ -60612,9 +72888,9 @@ class Mission
 							headgear="OPT_H_HelmetO_ocamo";
 						};
 					};
-					id=6320;
+					id=6350;
 					type="OPT_CSAT_PA_Schuetze";
-					atlOffset=209.63693;
+					atlOffset=76.669144;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60632,7 +72908,7 @@ class Mission
 											"STRING"
 										};
 									};
-									value="Male01PER";
+									value="Male03PER";
 								};
 							};
 						};
@@ -60651,7 +72927,7 @@ class Mission
 											"SCALAR"
 										};
 									};
-									value=0.94999999;
+									value=1.01;
 								};
 							};
 						};
@@ -60663,9 +72939,9 @@ class Mission
 			{
 			};
 			id=6310;
-			atlOffset=209.24878;
+			atlOffset=75.863556;
 		};
-		class Item6
+		class Item5
 		{
 			dataType="Group";
 			side="East";
@@ -60677,8 +72953,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={33.862144,23.280216,9237.6133};
-						angles[]={0,1.5011578,0};
+						position[]={14114.963,23.628422,12366.704};
+						angles[]={0,2.0497439,0};
 					};
 					side="East";
 					flags=3;
@@ -60763,7 +73039,7 @@ class Mission
 					};
 					id=6322;
 					type="OPT_CSAT_Gruppenfuehrer";
-					atlOffset=209.24878;
+					atlOffset=75.025253;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60812,8 +73088,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.101244,23.280216,9239.3105};
-						angles[]={0,1.5237739,0};
+						position[]={14113.494,23.628422,12369.595};
+						angles[]={0,2.0723603,0};
 					};
 					side="East";
 					class Attributes
@@ -60891,7 +73167,7 @@ class Mission
 					};
 					id=6323;
 					type="OPT_CSAT_Operator";
-					atlOffset=209.24878;
+					atlOffset=75.583542;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -60940,8 +73216,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.122042,23.280216,9237.3994};
-						angles[]={0,1.4950603,0};
+						position[]={14112.514,23.628422,12367.953};
+						angles[]={0,2.0436468,0};
 					};
 					side="East";
 					flags=1;
@@ -61040,7 +73316,7 @@ class Mission
 					};
 					id=6324;
 					type="OPT_CSAT_Luftabwehrspezialist";
-					atlOffset=209.24878;
+					atlOffset=75.583534;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61089,15 +73365,15 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.246775,23.280216,9235.4854};
-						angles[]={0,1.5180874,0};
+						position[]={14111.623,23.628746,12366.252};
+						angles[]={0,2.0666792,0};
 					};
 					side="East";
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Adler""];}";
 						name="csat_MAAWS";
-						description="MAAWS-Schütze@Adler";
+						description="Light AT-Schütze@Adler";
 						isPlayable=1;
 						class Inventory
 						{
@@ -61111,15 +73387,6 @@ class Mission
 								{
 									name="30Rnd_580x42_Mag_F";
 									ammoLeft=30;
-								};
-							};
-							class secondaryWeapon
-							{
-								name="launch_MRAWS_green_rail_F";
-								class primaryMuzzleMag
-								{
-									name="MRAWS_HEAT_F";
-									ammoLeft=1;
 								};
 							};
 							class binocular
@@ -61166,16 +73433,6 @@ class Mission
 							{
 								typeName="B_ViperHarness_hex_F";
 								isBackpack=1;
-								class MagazineCargo
-								{
-									items=1;
-									class Item0
-									{
-										name="MRAWS_HEAT_F";
-										count=1;
-										ammoLeft=1;
-									};
-								};
 							};
 							map="ItemMap";
 							compass="ItemCompass";
@@ -61187,7 +73444,7 @@ class Mission
 					};
 					id=6325;
 					type="OPT_CSAT_PA_Schuetze";
-					atlOffset=209.24878;
+					atlOffset=75.336319;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61236,8 +73493,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.876778,23.280216,9239.1865};
-						angles[]={0,1.5153471,0};
+						position[]={14111.529,23.628422,12370.647};
+						angles[]={0,2.0639336,0};
 					};
 					side="East";
 					flags=1;
@@ -61323,7 +73580,7 @@ class Mission
 					};
 					id=6326;
 					type="OPT_CSAT_LMG_Schuetze";
-					atlOffset=209.24878;
+					atlOffset=75.811417;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61372,8 +73629,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.93914,23.280216,9237.3145};
-						angles[]={0,1.4666874,0};
+						position[]={14110.609,23.628422,12369.019};
+						angles[]={0,2.0152738,0};
 					};
 					side="East";
 					flags=1;
@@ -61461,7 +73718,7 @@ class Mission
 					};
 					id=6327;
 					type="OPT_CSAT_Sanitaeter";
-					atlOffset=209.24878;
+					atlOffset=75.869614;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61510,8 +73767,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={29.022301,23.280216,9235.3828};
-						angles[]={0,1.4902843,0};
+						position[]={14109.67,23.628422,12367.326};
+						angles[]={0,2.0388708,0};
 					};
 					side="East";
 					flags=1;
@@ -61585,7 +73842,7 @@ class Mission
 					};
 					id=6328;
 					type="OPT_CSAT_Soldat";
-					atlOffset=209.24878;
+					atlOffset=75.876373;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61634,8 +73891,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.714676,23.668369,9237.0869};
-						angles[]={0,1.4967828,0};
+						position[]={14108.59,23.671078,12369.984};
+						angles[]={0,2.0453687,0};
 					};
 					side="East";
 					flags=5;
@@ -61721,7 +73978,7 @@ class Mission
 					};
 					id=6330;
 					type="OPT_CSAT_Scharfschuetze";
-					atlOffset=0.00018882751;
+					atlOffset=0.0030479431;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61770,8 +74027,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.839409,23.668369,9235.1943};
-						angles[]={0,1.4504559,0};
+						position[]={14107.709,23.735113,12368.307};
+						angles[]={0,1.9990423,0};
 					};
 					side="East";
 					flags=5;
@@ -61850,7 +74107,7 @@ class Mission
 					};
 					id=6331;
 					type="OPT_CSAT_Beobachter";
-					atlOffset=0.00025749207;
+					atlOffset=0.067153931;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -61899,8 +74156,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.455509,0.3717382,9239.041};
-						angles[]={0,1.5463617,0};
+						position[]={14109.386,0.71994472,12371.787};
+						angles[]={0,2.0949481,0};
 					};
 					side="East";
 					flags=1;
@@ -62035,7 +74292,7 @@ class Mission
 					};
 					id=6432;
 					type="OPT_CSAT_Aufklaerung_JTAC";
-					atlOffset=186.3403;
+					atlOffset=53.222683;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62084,9 +74341,9 @@ class Mission
 			{
 			};
 			id=6321;
-			atlOffset=209.24878;
+			atlOffset=75.025253;
 		};
-		class Item7
+		class Item6
 		{
 			dataType="Group";
 			side="East";
@@ -62098,8 +74355,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={34.643623,23.280216,9231.458};
-						angles[]={0,1.5658046,0};
+						position[]={14112.42,23.628422,12361.045};
+						angles[]={0,2.1143904,0};
 					};
 					side="East";
 					flags=3;
@@ -62184,7 +74441,7 @@ class Mission
 					};
 					id=6333;
 					type="OPT_CSAT_Gruppenfuehrer";
-					atlOffset=209.24878;
+					atlOffset=73.955688;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62233,8 +74490,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.439623,23.280216,9233.3066};
-						angles[]={0,1.5525402,0};
+						position[]={14110.652,23.628422,12364.294};
+						angles[]={0,2.1011267,0};
 					};
 					side="East";
 					flags=1;
@@ -62322,7 +74579,7 @@ class Mission
 					};
 					id=6334;
 					type="OPT_CSAT_Sanitaeter";
-					atlOffset=209.24878;
+					atlOffset=74.944336;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62371,8 +74628,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.602625,23.280216,9231.4053};
-						angles[]={0,1.4878932,0};
+						position[]={14109.798,23.628422,12362.586};
+						angles[]={0,2.0364797,0};
 					};
 					side="East";
 					flags=1;
@@ -62460,7 +74717,7 @@ class Mission
 					};
 					id=6335;
 					type="OPT_CSAT_Sanitaeter";
-					atlOffset=209.24878;
+					atlOffset=74.788483;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62509,8 +74766,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.928629,23.280216,9229.2344};
-						angles[]={0,1.4294945,0};
+						position[]={14108.942,23.628422,12360.561};
+						angles[]={0,1.978081,0};
 					};
 					side="East";
 					flags=1;
@@ -62596,7 +74853,7 @@ class Mission
 					};
 					id=6336;
 					type="OPT_CSAT_LMG_Schuetze";
-					atlOffset=209.24878;
+					atlOffset=74.571579;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62645,8 +74902,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={29.12162,23.280216,9233.1631};
-						angles[]={0,1.4902843,0};
+						position[]={14108.6,23.628422,12365.381};
+						angles[]={0,2.0388708,0};
 					};
 					side="East";
 					flags=1;
@@ -62720,7 +74977,7 @@ class Mission
 					};
 					id=6337;
 					type="OPT_CSAT_Soldat";
-					atlOffset=209.24878;
+					atlOffset=75.573349;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62769,8 +75026,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={29.250626,23.280216,9231.1123};
-						angles[]={0,1.491733,0};
+						position[]={14107.639,23.628422,12363.561};
+						angles[]={0,2.040319,0};
 					};
 					side="East";
 					flags=1;
@@ -62844,7 +75101,7 @@ class Mission
 					};
 					id=6338;
 					type="OPT_CSAT_Soldat";
-					atlOffset=209.24878;
+					atlOffset=75.417397;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -62893,8 +75150,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={29.349625,23.280216,9228.9883};
-						angles[]={0,1.4855543,0};
+						position[]={14106.613,23.628422,12361.699};
+						angles[]={0,2.0341406,0};
 					};
 					side="East";
 					flags=1;
@@ -62998,7 +75255,7 @@ class Mission
 					};
 					id=6339;
 					type="OPT_CSAT_Grenadier";
-					atlOffset=209.24878;
+					atlOffset=75.085938;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63047,8 +75304,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.772621,23.668369,9230.8145};
-						angles[]={0,1.4902843,0};
+						position[]={14105.368,23.725586,12364.601};
+						angles[]={0,2.0388708,0};
 					};
 					side="East";
 					flags=5;
@@ -63122,7 +75379,7 @@ class Mission
 					};
 					id=6340;
 					type="OPT_CSAT_Soldat";
-					atlOffset=0.00024986267;
+					atlOffset=0.057619095;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63171,8 +75428,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.634621,23.668369,9232.7939};
-						angles[]={0,1.4797949,6.2826972};
+						position[]={14106.283,23.713886,12366.361};
+						angles[]={6.2829447,2.0283816,6.2827773};
 					};
 					side="East";
 					flags=4;
@@ -63286,7 +75543,7 @@ class Mission
 					};
 					id=6341;
 					type="OPT_CSAT_Sprengmeister";
-					atlOffset=0.00017356873;
+					atlOffset=0.045841217;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63335,8 +75592,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={27.06934,23.668369,9228.7432};
-						angles[]={0,1.4597759,0};
+						position[]={14104.543,23.705986,12362.678};
+						angles[]={0,2.0083628,0};
 					};
 					side="East";
 					flags=5;
@@ -63440,7 +75697,7 @@ class Mission
 					};
 					id=6342;
 					type="OPT_CSAT_Grenadier";
-					atlOffset=0.00040245056;
+					atlOffset=0.038171768;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63489,9 +75746,9 @@ class Mission
 			{
 			};
 			id=6332;
-			atlOffset=209.24878;
+			atlOffset=73.955688;
 		};
-		class Item8
+		class Item7
 		{
 			dataType="Group";
 			side="East";
@@ -63503,8 +75760,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={33.192169,23.280216,9243.9248};
-						angles[]={0,1.4753791,0};
+						position[]={14117.681,23.628422,12372.44};
+						angles[]={0,2.0239656,0};
 					};
 					side="East";
 					flags=3;
@@ -63589,7 +75846,7 @@ class Mission
 					};
 					id=6344;
 					type="OPT_CSAT_Gruppenfuehrer";
-					atlOffset=209.24878;
+					atlOffset=75.51506;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63638,8 +75895,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={30.585169,23.280216,9245.2266};
-						angles[]={0,1.4799519,0};
+						position[]={14116.137,23.628422,12374.91};
+						angles[]={0,2.0285385,0};
 					};
 					side="East";
 					flags=1;
@@ -63724,7 +75981,7 @@ class Mission
 					};
 					id=6345;
 					type="OPT_CSAT_Gruppenfuehrer";
-					atlOffset=209.24878;
+					atlOffset=76.242012;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63773,8 +76030,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={30.911173,23.280216,9243.5986};
-						angles[]={0,1.4621147,0};
+						position[]={14115.57,23.628422,12373.35};
+						angles[]={0,2.0107009,0};
 					};
 					side="East";
 					flags=1;
@@ -63862,7 +76119,7 @@ class Mission
 					};
 					id=6346;
 					type="OPT_CSAT_Sanitaeter";
-					atlOffset=209.24878;
+					atlOffset=76.058449;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -63911,8 +76168,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.305168,23.280216,9245.0449};
-						angles[]={0,1.4762344,0};
+						position[]={14114.097,23.628422,12375.945};
+						angles[]={0,2.0248208,0};
 					};
 					side="East";
 					class Attributes
@@ -64025,7 +76282,7 @@ class Mission
 					};
 					id=6348;
 					type="OPT_CSAT_Sprengmeister";
-					atlOffset=209.24878;
+					atlOffset=76.394012;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -64074,8 +76331,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.652168,23.280216,9243.2988};
-						angles[]={0,1.5502188,0};
+						position[]={14113.485,23.628422,12374.271};
+						angles[]={0,2.0988061,0};
 					};
 					side="East";
 					flags=1;
@@ -64194,7 +76451,7 @@ class Mission
 					};
 					id=6349;
 					type="OPT_CSAT_Grenadier";
-					atlOffset=209.24878;
+					atlOffset=76.325775;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -64243,158 +76500,11 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.873169,23.280216,9241.7344};
-						angles[]={0,1.4737211,0};
+						position[]={14110.828,23.667091,12373.845};
+						angles[]={0,2.1196094,0};
 					};
 					side="East";
-					class Attributes
-					{
-						init="call{(group this) setGroupIdGlobal [""Geko""];}";
-						name="csat_MAAWS_1";
-						description="MAAWS-Schütze@Geko";
-						isPlayable=1;
-						class Inventory
-						{
-							class primaryWeapon
-							{
-								name="OPT_arifle_CTAR_blk_F";
-								optics="optic_ACO_grn";
-								muzzle="ACE_muzzle_mzls_L";
-								flashlight="acc_pointer_IR";
-								class primaryMuzzleMag
-								{
-									name="30Rnd_580x42_Mag_F";
-									ammoLeft=30;
-								};
-							};
-							class secondaryWeapon
-							{
-								name="launch_MRAWS_green_rail_F";
-								class primaryMuzzleMag
-								{
-									name="MRAWS_HEAT_F";
-									ammoLeft=1;
-								};
-							};
-							class binocular
-							{
-								name="Rangefinder";
-							};
-							class uniform
-							{
-								typeName="U_O_officer_noInsignia_hex_F";
-								isBackpack=0;
-								class MagazineCargo
-								{
-									items=1;
-									class Item0
-									{
-										name="30Rnd_580x42_Mag_F";
-										count=3;
-										ammoLeft=30;
-									};
-								};
-							};
-							class vest
-							{
-								typeName="OPT_V_TacVest_khk";
-								isBackpack=0;
-								class MagazineCargo
-								{
-									items=2;
-									class Item0
-									{
-										name="HandGrenade";
-										count=3;
-										ammoLeft=1;
-									};
-									class Item1
-									{
-										name="SmokeShell";
-										count=2;
-										ammoLeft=1;
-									};
-								};
-							};
-							class backpack
-							{
-								typeName="B_ViperHarness_hex_F";
-								isBackpack=1;
-								class MagazineCargo
-								{
-									items=1;
-									class Item0
-									{
-										name="MRAWS_HEAT_F";
-										count=1;
-										ammoLeft=1;
-									};
-								};
-							};
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-							radio="tf_fadak";
-							gps="ItemGPS";
-							headgear="OPT_H_HelmetO_ocamo";
-						};
-					};
-					id=6350;
-					type="OPT_CSAT_PA_Schuetze";
-					atlOffset=209.24878;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03PER";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={26.610172,23.668369,9241.5498};
-						angles[]={0,1.5710232,0};
-					};
-					side="East";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Geko""];}";
@@ -64477,7 +76587,7 @@ class Mission
 					};
 					id=6351;
 					type="OPT_CSAT_Scharfschuetze";
-					atlOffset=0.00011634827;
+					atlOffset=76.317856;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -64521,13 +76631,13 @@ class Mission
 						nAttributes=2;
 					};
 				};
-				class Item7
+				class Item6
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.369171,23.668377,9243.0381};
-						angles[]={0,1.5019431,0};
+						position[]={14111.398,23.725483,12375.241};
+						angles[]={0,2.050529,0};
 					};
 					side="East";
 					flags=5;
@@ -64600,6 +76710,7 @@ class Mission
 					};
 					id=6352;
 					type="OPT_CSAT_MG_Schuetze";
+					atlOffset=0.057256699;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -64643,16 +76754,16 @@ class Mission
 						nAttributes=2;
 					};
 				};
-				class Item8
+				class Item7
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.080173,23.668369,9244.626};
-						angles[]={0,1.4539814,0};
+						position[]={14111.98,23.818344,12376.748};
+						angles[]={0,2.002568,0};
 					};
 					side="East";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						init="call{(group this) setGroupIdGlobal [""Geko""];}";
@@ -64748,7 +76859,7 @@ class Mission
 					};
 					id=6353;
 					type="OPT_CSAT_Luftabwehrspezialist";
-					atlOffset=209.63693;
+					atlOffset=0.14997101;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -64792,13 +76903,13 @@ class Mission
 						nAttributes=2;
 					};
 				};
-				class Item9
+				class Item8
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.226946,0.30207962,9241.9512};
-						angles[]={0,1.5463617,0};
+						position[]={14114.975,0.65028453,12371.78};
+						angles[]={0,2.0949481,0};
 					};
 					side="East";
 					flags=1;
@@ -64933,7 +77044,7 @@ class Mission
 					};
 					id=6434;
 					type="OPT_CSAT_Aufklaerung_JTAC";
-					atlOffset=186.27065;
+					atlOffset=52.940453;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -64977,14 +77088,151 @@ class Mission
 						nAttributes=2;
 					};
 				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={14112.81,0.049351454,12372.785};
+						angles[]={0,2.0682499,0};
+					};
+					side="East";
+					flags=1;
+					class Attributes
+					{
+						init="call{(group this) setGroupIdGlobal [""Geko""];}";
+						name="csat_lat";
+						description="Heavy AT-Schütze@Gecko";
+						isPlayable=1;
+						class Inventory
+						{
+							class primaryWeapon
+							{
+								name="OPT_arifle_CTAR_blk_F";
+								optics="optic_ACO_grn";
+								flashlight="acc_pointer_IR";
+								class primaryMuzzleMag
+								{
+									name="30Rnd_580x42_Mag_F";
+									ammoLeft=30;
+								};
+							};
+							class binocular
+							{
+								name="Rangefinder";
+							};
+							class uniform
+							{
+								typeName="U_O_officer_noInsignia_hex_F";
+								isBackpack=0;
+								class MagazineCargo
+								{
+									items=1;
+									class Item0
+									{
+										name="30Rnd_580x42_Mag_F";
+										count=3;
+										ammoLeft=30;
+									};
+								};
+								class ItemCargo
+								{
+									items=1;
+									class Item0
+									{
+										name="FirstAidKit";
+										count=2;
+									};
+								};
+							};
+							class vest
+							{
+								typeName="OPT_V_TacVest_khk";
+								isBackpack=0;
+								class MagazineCargo
+								{
+									items=2;
+									class Item0
+									{
+										name="HandGrenade";
+										count=2;
+										ammoLeft=1;
+									};
+									class Item1
+									{
+										name="SmokeShell";
+										count=2;
+										ammoLeft=1;
+									};
+								};
+							};
+							class backpack
+							{
+								typeName="B_FieldPack_ocamo";
+								isBackpack=1;
+							};
+							map="ItemMap";
+							compass="ItemCompass";
+							watch="ItemWatch";
+							radio="tf_fadak";
+							gps="ItemGPS";
+							headgear="OPT_H_HelmetO_ocamo";
+						};
+					};
+					id=8181;
+					type="OPT_CSAT_PA_Schuetze_Heavy";
+					atlOffset=52.516193;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male03PER";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.97000003;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
 			};
 			class Attributes
 			{
 			};
 			id=6343;
-			atlOffset=209.24878;
+			atlOffset=75.51506;
 		};
-		class Item9
+		class Item8
 		{
 			dataType="Group";
 			side="East";
@@ -64996,8 +77244,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={33.435066,23.283375,9220.292};
-						angles[]={0,1.5151901,0};
+						position[]={14105.566,23.63158,12352.148};
+						angles[]={0,2.0637765,0};
 					};
 					side="East";
 					flags=3;
@@ -65086,7 +77334,7 @@ class Mission
 					};
 					id=6355;
 					type="OPT_CSAT_Besatzungsmitglied";
-					atlOffset=209.25194;
+					atlOffset=72.6353;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65135,8 +77383,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.102068,23.282703,9220.0869};
-						angles[]={0,1.5170227,0};
+						position[]={14103.469,23.630909,12353.191};
+						angles[]={0,2.065609,0};
 					};
 					side="East";
 					flags=1;
@@ -65225,7 +77473,7 @@ class Mission
 					};
 					id=6356;
 					type="OPT_CSAT_Besatzungsmitglied";
-					atlOffset=209.25127;
+					atlOffset=73.41156;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65274,8 +77522,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={30.995073,23.668308,9222.0293};
-						angles[]={0,1.5181397,0};
+						position[]={14104.389,23.706228,12354.904};
+						angles[]={0,2.0667255,0};
 					};
 					side="East";
 					flags=5;
@@ -65364,7 +77612,7 @@ class Mission
 					};
 					id=6357;
 					type="OPT_CSAT_Besatzungsmitglied";
-					atlOffset=0.0022583008;
+					atlOffset=0.040328979;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65413,8 +77661,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={31.222071,23.289494,9218.2412};
-						angles[]={0,1.5166214,0};
+						position[]={14102.609,23.637699,12351.552};
+						angles[]={0,2.065208,0};
 					};
 					side="East";
 					flags=1;
@@ -65503,7 +77751,7 @@ class Mission
 					};
 					id=6358;
 					type="OPT_CSAT_Besatzungsmitglied";
-					atlOffset=209.25806;
+					atlOffset=72.888184;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65552,8 +77800,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.995575,23.288288,9218.208};
-						angles[]={0,1.5707964,0};
+						position[]={14100.689,23.636494,12352.686};
+						angles[]={0,2.1193819,0};
 					};
 					side="East";
 					flags=1;
@@ -65653,7 +77901,7 @@ class Mission
 					};
 					id=6359;
 					type="OPT_CSAT_Pionier";
-					atlOffset=209.25685;
+					atlOffset=73.818176;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65702,8 +77950,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.831497,23.281727,9219.9873};
-						angles[]={0,1.5707964,0};
+						position[]={14101.479,23.629932,12354.289};
+						angles[]={0,2.1193819,0};
 					};
 					side="East";
 					flags=1;
@@ -65803,7 +78051,7 @@ class Mission
 					};
 					id=6360;
 					type="OPT_CSAT_Pionier";
-					atlOffset=209.25029;
+					atlOffset=74.069397;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65852,8 +78100,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.862534,23.288029,9217.9258};
-						angles[]={0,1.5374955,0};
+						position[]={14098.725,23.636234,12353.557};
+						angles[]={0,2.0860815,0};
 					};
 					side="East";
 					flags=1;
@@ -65927,7 +78175,7 @@ class Mission
 					};
 					id=6361;
 					type="OPT_CSAT_Soldat";
-					atlOffset=209.25659;
+					atlOffset=74.072556;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -65976,8 +78224,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.440613,23.281286,9219.707};
-						angles[]={0,1.4902843,0};
+						position[]={14099.295,23.629492,12355.299};
+						angles[]={0,2.0388708,0};
 					};
 					side="East";
 					flags=1;
@@ -66051,7 +78299,7 @@ class Mission
 					};
 					id=6362;
 					type="OPT_CSAT_Soldat";
-					atlOffset=209.24985;
+					atlOffset=74.543442;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -66100,8 +78348,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={26.39373,23.668369,9221.5107};
-						angles[]={0,1.4856941,0};
+						position[]={14100.191,23.696959,12356.861};
+						angles[]={0,2.0342808,0};
 					};
 					side="East";
 					flags=5;
@@ -66175,7 +78423,7 @@ class Mission
 					};
 					id=6363;
 					type="OPT_CSAT_Soldat";
-					atlOffset=0.00011634827;
+					atlOffset=0.028858185;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -66224,8 +78472,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={28.73774,23.668369,9221.793};
-						angles[]={0,1.4902668,0};
+						position[]={14102.34,23.706797,12355.877};
+						angles[]={0,2.0388532,0};
 					};
 					side="East";
 					flags=5;
@@ -66299,7 +78547,7 @@ class Mission
 					};
 					id=6364;
 					type="OPT_CSAT_Soldat";
-					atlOffset=0.0012378693;
+					atlOffset=0.03981781;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -66348,9 +78596,9 @@ class Mission
 			{
 			};
 			id=6354;
-			atlOffset=209.25194;
+			atlOffset=72.6353;
 		};
-		class Item10
+		class Item9
 		{
 			dataType="Group";
 			side="East";
@@ -66362,8 +78610,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={36.180443,23.280216,9240.9014};
-						angles[]={0,4.706058,0};
+						position[]={14118.656,23.628422,12368.302};
+						angles[]={0,5.2546692,0};
 					};
 					side="East";
 					flags=3;
@@ -66447,7 +78695,7 @@ class Mission
 					};
 					id=6366;
 					type="OPT_CSAT_Offizier";
-					atlOffset=209.24878;
+					atlOffset=74.669197;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -66496,999 +78744,7 @@ class Mission
 			{
 			};
 			id=6365;
-			atlOffset=209.24878;
-		};
-		class Item11
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={4925.6323,341.19653,21895.656};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1";
-			};
-			id=6367;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0014038086;
-		};
-		class Item12
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={4582.2017,299.6069,21385.365};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_1";
-			};
-			id=6370;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010986328;
-		};
-		class Item13
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={4910.3472,197.1022,19458.254};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_2";
-			};
-			id=6371;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011138916;
-		};
-		class Item14
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3360.3782,67.56945,18310.93};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_3";
-			};
-			id=6372;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.00054931641;
-		};
-		class Item15
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5410.8721,76.737549,17909.359};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_4";
-			};
-			id=6373;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011138916;
-		};
-		class Item16
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6181.8838,43.000999,16256.253};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_5";
-			};
-			id=6374;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.00099945068;
-		};
-		class Item17
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={4267.708,28.040495,13902.733};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_6";
-			};
-			id=6375;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010910034;
-		};
-		class Item18
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3723.6956,18.555311,12999.2};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_7";
-			};
-			id=6376;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.001127243;
-		};
-		class Item19
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5940.9346,101.7437,12461.137};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_8";
-			};
-			id=6377;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011367798;
-		};
-		class Item20
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={7233.4165,4.3041649,11030.594};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_9";
-			};
-			id=6378;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011081696;
-		};
-		class Item21
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9684.7617,3.5207906,22269.395};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_10";
-			};
-			id=6379;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011410713;
-		};
-		class Item22
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8532.0986,68.093964,20879.943};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_11";
-			};
-			id=6380;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.001335144;
-		};
-		class Item23
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9410.1563,118.25887,20300.502};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_12";
-			};
-			id=6381;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010910034;
-		};
-		class Item24
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={10405.196,120.67762,19023.145};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_13";
-			};
-			id=6382;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010528564;
-		};
-		class Item25
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={7533.3193,134.73981,18346.297};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_14";
-			};
-			id=6383;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0020904541;
-		};
-		class Item26
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={7111.4897,111.96675,16438.803};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_15";
-			};
-			id=6384;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011062622;
-		};
-		class Item27
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9196.6797,120.77501,15821.593};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_16";
-			};
-			id=6385;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011062622;
-		};
-		class Item28
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9301.5342,30.298265,13664.528};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_17";
-			};
-			id=6386;
-			type="Land_HelipadEmpty_F";
-			atlOffset=8.2015991e-005;
-		};
-		class Item29
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9468.4805,26.262537,8236.5488};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_18";
-			};
-			id=6387;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item30
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={12318.005,20.195953,22856.318};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_19";
-			};
-			id=6388;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010585785;
-		};
-		class Item31
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={13013.089,32.230129,19448.695};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_20";
-			};
-			id=6389;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011062622;
-		};
-		class Item32
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={12672.666,34.210361,16390.48};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_21";
-			};
-			id=6390;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item33
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={13248.13,13.200888,14947.823};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_22";
-			};
-			id=6391;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.00086307526;
-		};
-		class Item34
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={12151.891,9.668313,14330.698};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_23";
-			};
-			id=6392;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011320114;
-		};
-		class Item35
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11105.64,19.684849,13325.393};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_24";
-			};
-			id=6393;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item36
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={10675.173,16.757935,12266.578};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_25";
-			};
-			id=6394;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item37
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={10819.854,6.4413772,10859.053};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_26";
-			};
-			id=6395;
-			type="Land_HelipadEmpty_F";
-			atlOffset=7.1048737e-005;
-		};
-		class Item38
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11562.51,77.303802,7045.9185};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_27";
-			};
-			id=6396;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011062622;
-		};
-		class Item39
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={14266.871,43.789253,22215.367};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_28";
-			};
-			id=6397;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item40
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={14716.515,46.701706,20735.465};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_29";
-			};
-			id=6398;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item41
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={14320.399,36.900391,18909.221};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_30";
-			};
-			id=6399;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item42
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={14937.858,17.528454,17153.338};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_31";
-			};
-			id=6400;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.001241684;
-		};
-		class Item43
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={13589.743,16.363777,12166.921};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_32";
-			};
-			id=6401;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011081696;
-		};
-		class Item44
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11908.478,15.18861,9707.3877};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_33";
-			};
-			id=6402;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0013866425;
-		};
-		class Item45
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16587.895,35.317459,19002.33};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_34";
-			};
-			id=6403;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item46
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16451.031,24.131969,17237.797};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_35";
-			};
-			id=6404;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.00080680847;
-		};
-		class Item47
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16681.539,18.231377,16143.08};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_36";
-			};
-			id=6405;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item48
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16703.346,10.311413,13522.601};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_37";
-			};
-			id=6406;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item49
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16611.455,13.550769,12640.338};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_38";
-			};
-			id=6407;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item50
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={17769.818,41.113083,10566.192};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_39";
-			};
-			id=6408;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item51
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={19406.996,50.685932,7955.5903};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_40";
-			};
-			id=6409;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0013160706;
-		};
-		class Item52
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={18943.773,28.606129,16660.947};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_41";
-			};
-			id=6410;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.00097465515;
-		};
-		class Item53
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={18420.234,49.431179,15511.571};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_42";
-			};
-			id=6411;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item54
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={18147.764,25.077732,15225.152};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_43";
-			};
-			id=6412;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010070801;
-		};
-		class Item55
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={19702.965,89.270676,12960.619};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_44";
-			};
-			id=6413;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011062622;
-		};
-		class Item56
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={20155.959,41.908695,11718.664};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_45";
-			};
-			id=6414;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0012359619;
-		};
-		class Item57
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={20555.693,39.293385,9022.5293};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_46";
-			};
-			id=6415;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item58
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={20907.025,34.035168,6664.6289};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_47";
-			};
-			id=6416;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item59
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={20092.324,17.621887,20026.533};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_48";
-			};
-			id=6417;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010795593;
-		};
-		class Item60
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={20958.469,15.521555,19261.99};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_49";
-			};
-			id=6418;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.001039505;
-		};
-		class Item61
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={50940,-185.879,17008};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_50";
-			};
-			id=6419;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010070801;
-		};
-		class Item62
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={21373.045,18.855602,16254.126};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_51";
-			};
-			id=6420;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.00089836121;
-		};
-		class Item63
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={21185.318,2.11974,14617.707};
-				angles[]={6.2738504,0,6.2658529};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_52";
-			};
-			id=6421;
-			type="Land_HelipadEmpty_F";
-		};
-		class Item64
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={22010.072,29.125452,21064.441};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_53";
-			};
-			id=6422;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0010356903;
-		};
-		class Item65
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={22283.615,14.165822,18499.398};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_54";
-			};
-			id=6423;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item66
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={22599.842,13.634861,16825.371};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_55";
-			};
-			id=6424;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item67
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={23371.816,3.9426758,24183.539};
-				angles[]={0,3.2299411,0};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_56";
-			};
-			id=6425;
-			type="Land_HelipadEmpty_F";
-		};
-		class Item68
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={23466.807,90.535362,21137.943};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_57";
-			};
-			id=6426;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011367798;
-		};
-		class Item69
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={24755.986,3.8023796,19153.188};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_58";
-			};
-			id=6427;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0013420582;
-		};
-		class Item70
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={26731.115,20.005753,24638.008};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_59";
-			};
-			id=6428;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item71
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={26989.885,20.367672,23206.453};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_60";
-			};
-			id=6429;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
-		};
-		class Item72
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={25420.861,10.028322,20338.611};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="b1_61";
-			};
-			id=6430;
-			type="Land_HelipadEmpty_F";
-			atlOffset=0.0011100769;
+			atlOffset=74.669197;
 		};
 	};
 };

--- a/OPT_mission.Altis/sectorcontrol/functions/fnc_setup_flagpositions.sqf
+++ b/OPT_mission.Altis/sectorcontrol/functions/fnc_setup_flagpositions.sqf
@@ -10,176 +10,176 @@ east -> Angriffsziel für NATO
 GVARMAIN(nato_flags_pos) = [
 
 // Basis 
-	   [4913, 21907, west,"1 - Throns castel",true], // 1 - Throns_castel
-	   [4618, 21363, west,"2 - Oreokastro",true], // 2 - Oreokastro
-	   [4872, 19455, west,"3 - Waffenlager Nord West",true], // 3 - Waffenlager_Nord_West
-	   [3354, 18329, west,"4 - Villa Constans",true], // 4 - Villa_Constans
+	   [4913, 21907, west,"1 - Throns castel",false], // 1 - Throns_castel
+	   [4618, 21363, west,"2 - Oreokastro",false], // 2 - Oreokastro
+	   [4872, 19455, west,"3 - Waffenlager Nord West",false], // 3 - Waffenlager_Nord_West
+	   [3354, 18329, west,"4 - Villa Constans",false], // 4 - Villa_Constans
 
-	   [5398, 17888, west,"5 - Mine Gore",true], // 5 - Mine_Gore
-	   [6210, 16240, west,"6 - Kore Fabrik",true], // 6 - Kore_Fabrik
-	   [4264, 13929, west,"7 - Checkpoint charlie",true], // 7 - Checkpoint_charlie
-	   [3739, 12997, west,"8 - Kavala Hospital",true], // 8 - Kavala_Hospital
+	   [5398, 17888, west,"5 - Mine Gore",false], // 5 - Mine_Gore
+	   [6210, 16240, west,"6 - Kore Fabrik",false], // 6 - Kore_Fabrik
+	   [4264, 13929, west,"7 - Checkpoint charlie",false], // 7 - Checkpoint_charlie
+	   [3739, 12997, west,"8 - Kavala Hospital",false], // 8 - Kavala_Hospital
 
-	   [5924, 12469, west,"9 - Lager Panagiotis",true], // 9 - Lager_Panagiotis
-	   [12608, 14284, west,"10 - Edessa",true], // 10 - Edessa
-	   [9710, 22282, west,"11 - Krya Nera",true], // 11 - Krya_Nera
-	   [8560, 20883, west,"12 - Abdera Farm",true], // 12 - Abdera_Farm
+	   [5924, 12469, west,"9 - Lager Panagiotis",false], // 9 - Lager_Panagiotis
+	   [12608, 14284, west,"10 - Edessa",false], // 10 - Edessa
+	   [9710, 22282, west,"11 - Krya Nera",false], // 11 - Krya_Nera
+	   [8560, 20883, west,"12 - Abdera Farm",false], // 12 - Abdera_Farm
 	   
-	   [9423, 20273, west,"13 - Abdera Rathaus",true], // 13 - Abdera_Rathaus
-	   [10351, 19030, west,"14 - Galati alte Post",true], // 14 - Galati_alte_Post
-	   [7515, 18333, west,"15 - Enclave Syrta",true], // 15 - Enclave_Syrta
+	   [9423, 20273, west,"13 - Abdera Rathaus",false], // 13 - Abdera_Rathaus
+	   [10351, 19030, west,"14 - Galati alte Post",false], // 14 - Galati_alte_Post
+	   [7515, 18333, west,"15 - Enclave Syrta",false], // 15 - Enclave_Syrta
 
-	   [7174, 16468, west,"16 - Kore Zentrum",true], // 16 - Kore_Zentrum
-	   [9239, 15829, west,"17 - Checkpoint Agios Dionisos",true], // 17 - Checkpoint Agios Dionisos
-	   [9321, 13699, west,"18 - Xirolimni Damm",true], // 18 - Xirolimni_Damm",true
+	   [7174, 16468, west,"16 - Kore Zentrum",false], // 16 - Kore_Zentrum
+	   [9239, 15829, west,"17 - Checkpoint Agios Dionisos",false], // 17 - Checkpoint Agios Dionisos
+	   [9321, 13699, west,"18 - Xirolimni Damm",false], // 18 - Xirolimni_Damm",false
 	   
-	   [9489, 8236, west,"19 - Hühnerfarm Sfaka",true], // 19 - Hühnerfarm_Sfaka
+	   [9489, 8236, west,"19 - Hühnerfarm Sfaka",false], // 19 - Hühnerfarm_Sfaka
 
-	   [12346, 22844, west,"20 - Tonos Bucht",true], // 20 - Tonos_Bucht
-	   [13054, 19448, west,"21 - Checkpoint Ifestonia",true], // Checkpoint_Ifestonia
-	   [12634, 16399, west,"22 - Lacca Fabrik",true], // 22 - Lacca_Fabrik
+	   [12346, 22844, west,"20 - Tonos Bucht",false], // 20 - Tonos_Bucht
+	   [13054, 19448, west,"21 - Checkpoint Ifestonia",false], // Checkpoint_Ifestonia
+	   [12634, 16399, west,"22 - Lacca Fabrik",false], // 22 - Lacca_Fabrik
 
-	   [13273, 14969, west,"23 - Stavros Radar",true], // 23 - Stavros_Radar
-	   [12178, 14352, west,"24 - Neochori Wollmarkt",true], // 24 - Neochori_Wollmarkt
-	   [11083, 13363, west,"25 - Poliakko alte Brennerei",true], // 25 - Poliakko_alte_Brennerei
+	   [13273, 14969, west,"23 - Stavros Radar",false], // 23 - Stavros_Radar
+	   [12178, 14352, west,"24 - Neochori Wollmarkt",false], // 24 - Neochori_Wollmarkt
+	   [11083, 13363, west,"25 - Poliakko alte Brennerei",false], // 25 - Poliakko_alte_Brennerei
 	   
-	   [10676, 12234, west,"26 - Therisa Markt",true], // 26 - Therisa_Markt
-	   [10795, 10868, west,"27 - Drimea Fährstation",true], // 27 - Drimea_Fährstation
-	   [11536, 7047, west,"28 - Egino Farmhaus",true], // 28 - Egino_Farmhaus
+	   [10676, 12234, west,"26 - Therisa Markt",false], // 26 - Therisa_Markt
+	   [10795, 10868, west,"27 - Drimea Fährstation",false], // 27 - Drimea_Fährstation
+	   [11536, 7047, west,"28 - Egino Farmhaus",false], // 28 - Egino_Farmhaus
   
-	   [14283, 22224, west,"29 - Hanf Plantage Frini",true], // 29 - Hanf_Plantage_Frini 
-	   [14752, 20733, west,"30 - Frini Polizeistation",true], // 30 - Frini_Polizeistation
-	   [14325, 18928, west,"31 - Athira Factory",true], // 31 - Athira_Factory
+	   [14283, 22224, west,"29 - Hanf Plantage Frini",false], // 29 - Hanf_Plantage_Frini 
+	   [14752, 20733, west,"30 - Frini Polizeistation",false], // 30 - Frini_Polizeistation
+	   [14325, 18928, west,"31 - Athira Factory",false], // 31 - Athira_Factory
 	   
-	   [14920, 17172, west,"32 - Airbase Altis",true], // 32 - Airbase_Altis
-	   [13591, 15188, west,"33 - xxxxxxxxxxxxx",true], // 33 - xxxxxxxxxxxxx
-	   [11922, 9722, west,"34 - Alpaka Residenz",true], // 34 - Alpaka_Residenz
+	   [14920, 17172, west,"32 - Airbase Altis",false], // 32 - Airbase_Altis
+	   [13591, 15188, west,"33 - xxxxxxxxxxxxx",false], // 33 - xxxxxxxxxxxxx
+	   [11922, 9722, west,"34 - Alpaka Residenz",false], // 34 - Alpaka_Residenz
 	   
-	   [16603, 19042, west,"35 - Kalithea Kontrolltower",true], // 35 - Kalithea_Kontrolltower
+	   [16603, 19042, west,"35 - Kalithea Kontrolltower",false], // 35 - Kalithea_Kontrolltower
 	   
-	   [16459, 17202, west,"36 - Thelos Zentrum",true], // 36 - Thelos_Zentrum
-	   [16654, 16122, west,"37 - Athira Kirchplatz",true], // 37 - Athira_Kirchplatz
-	   [16720, 13548, west,"38 - xxxxxxxxxxx",true], // 38 _ xxxxxxxxxxxxxx
+	   [16459, 17202, west,"36 - Thelos Zentrum",false], // 36 - Thelos_Zentrum
+	   [16654, 16122, west,"37 - Athira Kirchplatz",false], // 37 - Athira_Kirchplatz
+	   [16720, 13548, west,"38 - xxxxxxxxxxx",false], // 38 _ xxxxxxxxxxxxxx
 
 	   [16589, 12635, west,"39 - Pyrgos Zentrum",true], // 39 - Pyrgos_Zentrum
-	   [17806, 10596, west,"40 - Ekali Stones",true], // 40 - Ekali Stones 
-	   [19422, 7972, west,"41 - Lonely",true], // 42 - Lonely
+	   [17806, 10596, west,"40 - Ekali Stones",false], // 40 - Ekali Stones 
+	   [19422, 7972, west,"41 - Lonely",false], // 42 - Lonely
 
-	   [18897, 16660, west,"42 - Rodopoli Graveyard",true], // 42 - Rodopoli Graveyard
-	   [18374, 15529, west,"43 - Charkia Storage",true], // 43 - Charkia Storage
-	   [18116, 15218, west,"44 - Charkia",true], // 44 - Charkia
+	   [18897, 16660, west,"42 - Rodopoli Graveyard",false], // 42 - Rodopoli Graveyard
+	   [18374, 15529, west,"43 - Charkia Storage",false], // 43 - Charkia Storage
+	   [18116, 15218, west,"44 - Charkia",false], // 44 - Charkia
 
 	   [19677, 12998, west,"45 - Dorida Woods",true], // 45 - Dorida Woods
-	   [20166, 11710, west,"46 - Chalikea",true], // 46 - Chalikea
-	   [20546, 9003, west,"47 - Panagia",true], // 47 - Panagia
+	   [20166, 11710, west,"46 - Chalikea",false], // 46 - Chalikea
+	   [20546, 9003, west,"47 - Panagia",false], // 47 - Panagia
 	   
-	   [20897, 6643, west,"48 - Selakano",true], // 48 - Selakano
-	   [20077, 20064, west,"49 - Pefka Colloseum",true], // 49 - Pefka Colloseum
-	   [20923, 19242, west,"50 - Pefkas Lab",true], // 50 - Pefkas Lab
+	   [20897, 6643, west,"48 - Selakano",false], // 48 - Selakano
+	   [20077, 20064, west,"49 - Pefka Colloseum",false], // 49 - Pefka Colloseum
+	   [20923, 19242, west,"50 - Pefkas Lab",false], // 50 - Pefkas Lab
 	   
 	   [20940, 17008, west,"51 - Paros",true], // 51 - Paros
 	   [21365, 16285, west,"52 - Kalochori",true], // 52 - Kalochori
 	   [21154, 14594, west,"53 - Limni Swamp",true], // 53 - Limni Swamp
 	   
-	   [21980, 21035, west,"54 - Pefkas Palace",true], // 54 - Pefkas Palace
-	   [22303, 18491, west,"55 - Almyra West",true], // 55 - Almyra West
+	   [21980, 21035, west,"54 - Pefkas Palace",false], // 54 - Pefkas Palace
+	   [22303, 18491, west,"55 - Almyra West",false], // 55 - Almyra West
 	   [22627, 16807, west,"56 - Almyra South",true], // 56 - Almyra South
 	   
-	   [23346, 24195, west,"57 - Sideras",true], // 57 - Sideras
-	   [23467, 21158, west,"58 - Delfinaki Military",true], // 58 - Delfinaki Military
-	   [24770, 19122, west,"59 - Almyra North",true], // 59 - Almyra North
+	   [23346, 24195, west,"57 - Sideras",false], // 57 - Sideras
+	   [23467, 21158, west,"58 - Delfinaki Military",false], // 58 - Delfinaki Military
+	   [24770, 19122, west,"59 - Almyra North",false], // 59 - Almyra North
 	   
-	   [26746, 24660, west,"60 - Molos Airbase",true], // 60 - Molos Airbase
-	   [26958, 23200, west,"61 - Molos Town",true], // 61 - Molos Town
-	   [25440, 20346, west,"62 - Refinery",true] // 62 - Refinery
+	   [26746, 24660, west,"60 - Molos Airbase",false], // 60 - Molos Airbase
+	   [26958, 23200, west,"61 - Molos Town",false], // 61 - Molos Town
+	   [25440, 20346, west,"62 - Refinery",false] // 62 - Refinery
 ];
 
 GVARMAIN(csat_flags_pos) = [
 
 //Basis 
 
-	   [4913, 21907, east,"1 - Throns castel",true], // 1 - Throns_castel
-	   [4618, 21363, east,"2 - Oreokastro",true], // 2 - Oreokastro
-	   [4872, 19455, east,"3 - Waffenlager Nord West",true], // 3 - Waffenlager_Nord_West
-	   [3354, 18329, east,"4 - Villa Constans",true], // 4 - Villa_Constans
+	   [4913, 21907, east,"1 - Throns castel",false], // 1 - Throns_castel
+	   [4618, 21363, east,"2 - Oreokastro",false], // 2 - Oreokastro
+	   [4872, 19455, east,"3 - Waffenlager Nord West",false], // 3 - Waffenlager_Nord_West
+	   [3354, 18329, east,"4 - Villa Constans",false], // 4 - Villa_Constans
 
-	   [5398, 17888, east,"5 - Mine Gore",true], // 5 - Mine_Gore
-	   [6210, 16240, east,"6 - Kore Fabrik",true], // 6 - Kore_Fabrik
-	   [4264, 13929, east,"7 - Checkpoint charlie",true], // 7 - Checkpoint_charlie
-	   [3739, 12997, east,"8 - Kavala Hospital",true], // 8 - Kavala_Hospital
+	   [5398, 17888, east,"5 - Mine Gore",false], // 5 - Mine_Gore
+	   [6210, 16240, east,"6 - Kore Fabrik",false], // 6 - Kore_Fabrik
+	   [4264, 13929, east,"7 - Checkpoint charlie",false], // 7 - Checkpoint_charlie
+	   [3739, 12997, east,"8 - Kavala Hospital",false], // 8 - Kavala_Hospital
 
-	   [5924, 12469, east,"9 - Lager Panagiotis",true], // 9 - Lager_Panagiotis
-	   [12608, 14284, east,"10 - Edessa",true], // 10 - Edessa
-	   [9710, 22282, east,"11 - Krya Nera",true], // 11 - Krya_Nera
-	   [8560, 20883, east,"12 - Abdera Farm",true], // 12 - Abdera_Farm
+	   [5924, 12469, east,"9 - Lager Panagiotis",false], // 9 - Lager_Panagiotis
+	   [12608, 14284, east,"10 - Edessa",false], // 10 - Edessa
+	   [9710, 22282, east,"11 - Krya Nera",false], // 11 - Krya_Nera
+	   [8560, 20883, east,"12 - Abdera Farm",false], // 12 - Abdera_Farm
 	   
-	   [9423, 20273, east,"13 - Abdera Rathaus",true], // 13 - Abdera_Rathaus
-	   [10351, 19030, east,"14 - Galati alte Post",true], // 14 - Galati_alte_Post
-	   [7515, 18333, east,"15 - Enclave Syrta",true], // 15 - Enclave_Syrta
+	   [9423, 20273, east,"13 - Abdera Rathaus",false], // 13 - Abdera_Rathaus
+	   [10351, 19030, east,"14 - Galati alte Post",false], // 14 - Galati_alte_Post
+	   [7515, 18333, east,"15 - Enclave Syrta",false], // 15 - Enclave_Syrta
 
-	   [7174, 16468, east,"16 - Kore Zentrum",true], // 16 - Kore_Zentrum
-	   [9239, 15829, east,"17 - Checkpoint Agios Dionisos",true], // 17 - Checkpoint Agios Dionisos
-	   [9321, 13699, east,"18 - Xirolimni Damm",true], // 18 - Xirolimni_Damm",true
+	   [7174, 16468, east,"16 - Kore Zentrum",false], // 16 - Kore_Zentrum
+	   [9239, 15829, east,"17 - Checkpoint Agios Dionisos",false], // 17 - Checkpoint Agios Dionisos
+	   [9321, 13699, east,"18 - Xirolimni Damm",false], // 18 - Xirolimni_Damm",false
 	   
-	   [9489, 8236, east,"19 - Hühnerfarm Sfaka",true], // 19 - Hühnerfarm_Sfaka
+	   [9489, 8236, east,"19 - Hühnerfarm Sfaka",false], // 19 - Hühnerfarm_Sfaka
 
-	   [12346, 22844, east,"20 - Tonos Bucht",true], // 20 - Tonos_Bucht
-	   [13054, 19448, east,"21 - Checkpoint Ifestonia",true], // Checkpoint_Ifestonia
-	   [12634, 16399, east,"22 - Lacca Fabrik",true], // 22 - Lacca_Fabrik
+	   [12346, 22844, east,"20 - Tonos Bucht",false], // 20 - Tonos_Bucht
+	   [13054, 19448, east,"21 - Checkpoint Ifestonia",false], // Checkpoint_Ifestonia
+	   [12634, 16399, east,"22 - Lacca Fabrik",false], // 22 - Lacca_Fabrik
 
-	   [13273, 14969, east,"23 - Stavros Radar",true], // 23 - Stavros_Radar
-	   [12178, 14352, east,"24 - Neochori Wollmarkt",true], // 24 - Neochori_Wollmarkt
-	   [11083, 13363, east,"25 - Poliakko alte Brennerei",true], // 25 - Poliakko_alte_Brennerei
+	   [13273, 14969, east,"23 - Stavros Radar",false], // 23 - Stavros_Radar
+	   [12178, 14352, east,"24 - Neochori Wollmarkt",false], // 24 - Neochori_Wollmarkt
+	   [11083, 13363, east,"25 - Poliakko alte Brennerei",false], // 25 - Poliakko_alte_Brennerei
 	   
-	   [10676, 12234, east,"26 - Therisa Markt",true], // 26 - Therisa_Markt
-	   [10795, 10868, east,"27 - Drimea Fährstation",true], // 27 - Drimea_Fährstation
-	   [11536, 7047, east,"28 - Egino Farmhaus",true], // 28 - Egino_Farmhaus
+	   [10676, 12234, east,"26 - Therisa Markt",false], // 26 - Therisa_Markt
+	   [10795, 10868, east,"27 - Drimea Fährstation",false], // 27 - Drimea_Fährstation
+	   [11536, 7047, east,"28 - Egino Farmhaus",false], // 28 - Egino_Farmhaus
   
-	   [14283, 22224, east,"29 - Hanf Plantage Frini",true], // 29 - Hanf_Plantage_Frini 
-	   [14752, 20733, east,"30 - Frini Polizeistation",true], // 30 - Frini_Polizeistation
-	   [14325, 18928, east,"31 - Athira Factory",true], // 31 - Athira_Factory
+	   [14283, 22224, east,"29 - Hanf Plantage Frini",false], // 29 - Hanf_Plantage_Frini 
+	   [14752, 20733, east,"30 - Frini Polizeistation",false], // 30 - Frini_Polizeistation
+	   [14325, 18928, east,"31 - Athira Factory",false], // 31 - Athira_Factory
 	   
-	   [14920, 17172, east,"32 - Airbase_Altis",true], // 32 - Airbase_Altis
-	   [13591, 15188, east,"33 - xxxxxxxxxxxxx",true], // 33 - xxxxxxxxxxxxx
-	   [11922, 9722, east,"34 - Alpaka_Residenz",true], // 34 - Alpaka_Residenz
+	   [14920, 17172, east,"32 - Airbase_Altis",false], // 32 - Airbase_Altis
+	   [13591, 15188, east,"33 - xxxxxxxxxxxxx",false], // 33 - xxxxxxxxxxxxx
+	   [11922, 9722, east,"34 - Alpaka_Residenz",false], // 34 - Alpaka_Residenz
 	   
-	   [16603, 19042, east,"35 - Kalithea Kontrolltower",true], // 35 - Kalithea_Kontrolltower
+	   [16603, 19042, east,"35 - Kalithea Kontrolltower",false], // 35 - Kalithea_Kontrolltower
 
 	   [16459, 17202, east,"36 - Thelos Zentrum",true], // 36 - Thelos_Zentrum
 	   [16654, 16122, east,"37 - Athira Kirchplatz",true], // 37 - Athira_Kirchplatz
 	   [16720, 13548, east,"38 - xxxxxxxxxxx",true], // 38 _ xxxxxxxxxxxxxx
 
-	   [16589, 12635, east,"39 - Pyrgos Zentrum",true], // 39 - Pyrgos_Zentrum
-	   [17806, 10596, east,"40 - Ekali Stones",true], // 40 - Ekali Stones 
-	   [19422, 7972, east,"41 - Lonely",true], // 42 - Lonely
+	   [16589, 12635, east,"39 - Pyrgos Zentrum",false], // 39 - Pyrgos_Zentrum
+	   [17806, 10596, east,"40 - Ekali Stones",false], // 40 - Ekali Stones 
+	   [19422, 7972, east,"41 - Lonely",false], // 42 - Lonely
 
 	   [18897, 16660, east,"42 - Rodopoli Graveyard",true], // 42 - Rodopoli Graveyard
 	   [18374, 15529, east,"43 - Charkia Storage",true], // 43 - Charkia Storage
 	   [18116, 15218, east,"44 - Charkia",true], // 44 - Charkia
 
-	   [19677, 12998, east,"45 - Dorida Woods",true], // 45 - Dorida Woods
-	   [20166, 11710, east,"46 - Chalikea",true], // 46 - Chalikea
-	   [20546, 9003, east,"47 - Panagia",true], // 47 - Panagia
+	   [19677, 12998, east,"45 - Dorida Woods",false], // 45 - Dorida Woods
+	   [20166, 11710, east,"46 - Chalikea",false], // 46 - Chalikea
+	   [20546, 9003, east,"47 - Panagia",false], // 47 - Panagia
 	   
-	   [20897, 6643, east,"48 - Selakano",true], // 48 - Selakano
-	   [20077, 20064, east,"49 - Pefka Colloseum",true], // 49 - Pefka Colloseum
-	   [20923, 19242, east,"50 - Pefkas Lab",true], // 50 - Pefkas Lab
+	   [20897, 6643, east,"48 - Selakano",false], // 48 - Selakano
+	   [20077, 20064, east,"49 - Pefka Colloseum",false], // 49 - Pefka Colloseum
+	   [20923, 19242, east,"50 - Pefkas Lab",false], // 50 - Pefkas Lab
 	   
-	   [20940, 17008, east,"51 - Paros",true], // 51 - Paros
-	   [21365, 16285, east,"52 - Kalochori",true], // 52 - Kalochori
-	   [21154, 14594, east,"53 - Limni Swamp",true], // 53 - Limni Swamp
+	   [20940, 17008, east,"51 - Paros",false], // 51 - Paros
+	   [21365, 16285, east,"52 - Kalochori",false], // 52 - Kalochori
+	   [21154, 14594, east,"53 - Limni Swamp",false], // 53 - Limni Swamp
 	   
-	   [21980, 21035, east,"54 - Pefkas Palace",true], // 54 - Pefkas Palace
-	   [22303, 18491, east,"55 - Almyra West",true], // 55 - Almyra West
-	   [22627, 16807, east,"56 - Almyra South",true], // 56 - Almyra South
+	   [21980, 21035, east,"54 - Pefkas Palace",false], // 54 - Pefkas Palace
+	   [22303, 18491, east,"55 - Almyra West",false], // 55 - Almyra West
+	   [22627, 16807, east,"56 - Almyra South",false], // 56 - Almyra South
 	   
-	   [23346, 24195, east,"57 - Sideras",true], // 57 - Sideras
-	   [23467, 21158, east,"58 - Delfinaki Military",true], // 58 - Delfinaki Military
-	   [24770, 19122, east,"59 - Almyra North",true], // 59 - Almyra North
+	   [23346, 24195, east,"57 - Sideras",false], // 57 - Sideras
+	   [23467, 21158, east,"58 - Delfinaki Military",false], // 58 - Delfinaki Military
+	   [24770, 19122, east,"59 - Almyra North",false], // 59 - Almyra North
 	   
-	   [26746, 24660, east,"60 - Molos Airbase",true], // 60 - Molos Airbase
-	   [26958, 23200, east,"61 - Molos Town",true], // 61 - Molos Town
-	   [25440, 20346, east,"62 - Refinery",true] // 62 - Refinery
+	   [26746, 24660, east,"60 - Molos Airbase",false], // 60 - Molos Airbase
+	   [26958, 23200, east,"61 - Molos Town",false], // 61 - Molos Town
+	   [25440, 20346, east,"62 - Refinery",false] // 62 - Refinery
 ];
 
 

--- a/OPT_mission.Altis/warehouse/functions/fnc_setupvehiclepool.sqf
+++ b/OPT_mission.Altis/warehouse/functions/fnc_setupvehiclepool.sqf
@@ -104,14 +104,13 @@ GVAR(nato_supplies) =
     ["OPT_Box_NATO_WpsSpecial_F", 60000, 10000, 20000],         // Munition spezial
     ["OPT_Box_NATO_Grenades_F", 75000, 10000, 20000],           // granatenkiste
     ["OPT_NATO_Sprengstoffkiste", 150000, 10000, 20000],        // sprengstoffkiste
-    ["OPT_Box_NATO_WpsSpecial_AT3_F", 130000, 10000, 20000],     // AT Raketenkiste (RPG-42)
+    ["OPT_Box_NATO_WpsSpecial_AT_L1", 200000, 10000, 20000],     // AT Raketenkiste (MRAWS)
+	["OPT_Box_NATO_WpsSpecial_AT_L2", 150000, 10000, 20000],     // AT Raketenkiste (PCML)
+	["OPT_Box_NATO_WpsSpecial_AT_H1", 350000, 10000, 20000],     // AT Raketenkiste (Titan)
     ["OPT_Box_NATO_WpsSpecial_AA_F", 140000, 10000, 20000],      // AA Raketenkiste
     ["OPT_B_supplyCrate_F", DEF_PROD(0)],                     // Transportkiste (leer)
     ["OPT_B_CargoNet_01_ammo_F", DEF_PROD(5000)],               // Ausrstungskiste
     ["OPT_Box_NATO_WpsSpecial_Diver_F", DEF_PROD(5000)],        // Taucherkiste    
-    ["OPT_Box_NATO_WpsSpecial_F", DEF_PROD(0)],                 // PCML-M Raketenkiste
-    ["OPT_Box_NATO_WpsSpecial_AT_F", DEF_PROD(0)],              // PCML Raketenkiste    
-    ["OPT_Box_NATO_WpsLaunch_F", DEF_PROD(0)],                  // HAT-Kiste (Titan)
     ["OPT_B_UGV_01_F", DEF_PROD(2000)],                         // UGV Stomper
     ["OPT_B_UAV_01_F", DEF_PROD(0)],                            // Darter AR-2
     ["OPT_FlexibleTank_01_forest_F", DEF_PROD(1000)],           // Treibstoff-Fass
@@ -212,11 +211,11 @@ GVAR(csat_choppers) =
     ["OPT4_O_Heli_Light_02_black_F", DEF_PROD(0)],              // PO-30 Orca (DAR)
     ["OPT_O_Heli_Light_02_F", DEF_PROD(0)],                     // PO-30 Orca (scalpel)
     ["OPT_O_Heli_Light_02_black_F", DEF_PROD(0)],               // PO-30 Orca (scalpel)
-    ["OPT_O_Heli_Transport_04_F", DEF_PROD(85000)],             // Mi-290 Taru (Lift)
+    ["OPT_O_Heli_Transport_04_F", DEF_PROD(0)],             // Mi-290 Taru (Lift)
     ["OPT_O_Heli_Transport_04_black_F", DEF_PROD(0)],           // Mi-290 Taru (Lift)
     ["OPT_O_Heli_Transport_04_covered_F", DEF_PROD(110000)],    // Mi-290 Taru (Transport)
     ["OPT_O_Heli_Transport_04_covered_black_F", DEF_PROD(0)],   // Mi-290 Taru (Transport)
-    ["OPT_O_Heli_Transport_04_bench_F", DEF_PROD(90000)],       // Mi-290 Taru (Bench)
+    ["OPT_O_Heli_Transport_04_bench_F", DEF_PROD(0)],       // Mi-290 Taru (Bench)
     ["OPT_O_Heli_Transport_04_bench_black_F", DEF_PROD(0)],     // Mi-290 Taru (Bench)
     ["OPT_O_UAV_02_light_F", DEF_PROD(300000)],                 // Ababil unbewaffnet
     ["OPT_O_UAV_02_CAS_F", DEF_PROD(0)],                        // Ababil GBU-12
@@ -268,12 +267,13 @@ GVAR(csat_supplies) =
     ["OPT_Box_East_WpsSpecial_F", 60000, 10000, 20000],                     // Munition spezial kiste
     ["OPT_Box_East_Grenades_F", 75000, 10000, 20000],                       // granatenkiste
     ["OPT_CSAT_Sprengstoffkiste", 150000, 10000, 20000],                    // sprengstoffkiste
-    ["OPT_Box_East_WpsSpecial_AT_F", 130000, 10000, 20000],                  // AT Raketenkiste (RPG-42)
+    ["OPT_Box_East_WpsSpecial_AT_L1", 200000, 10000, 20000],                  // AT Raketenkiste (RPG-42)
+	["OPT_Box_East_WpsSpecial_AT_L2", 150000, 10000, 20000],                  // AT Raketenkiste (RPG-7)
+	["OPT_Box_East_WpsSpecial_AT_H1", 350000, 10000, 20000],                  // AT Raketenkiste (9M135 Vorona)
     ["OPT_Box_East_WpsSpecial_AA_F", 140000, 10000, 20000],                  // AA Raketenkiste
     ["OPT_O_supplyCrate_F", DEF_PROD(500)],                                 // Transportkiste
-    ["OPT_O_CargoNet_01_ammo_F", DEF_PROD(0)],                           // Ausrstungskiste
+    ["OPT_O_CargoNet_01_ammo_F", DEF_PROD(5000)],                           // Ausrstungskiste
     ["OPT_Box_East_WpsSpecial_Diver_F", DEF_PROD(5000)],                    // Taucherkiste
-    ["OPT_Box_East_WpsLaunch_F", DEF_PROD(0)],                              // HAT-Kiste (Titan)
     ["OPT_O_T_UGV_01_ghex_F", DEF_PROD(0)],                                 // UGV Saif    
     ["OPT_O_UGV_01_F", DEF_PROD(2000)],                                     // UGV Saif    
     ["OPT_O_UAV_01_F", DEF_PROD(0)],                                        // Tayran AR-2


### PR DESCRIPTION

- Tageszeit für Schlacht eingestellt

- Träger in Posi gesetzt

- einige Fahnenpositionen etwas gestalltet 9, 20, 21, 23,40

- Fahnenpositionen als kleine rote Marker sichtbar.

- Checkpoints auf Frozen seinen Wunsch mit spetziellen kleinen Marker versehen.

- An Fahne 45 und 38 für Prologschlacht die Ausbauten wieder weggenommen.

-Neue  At Kisten hinzugefügt 

-Neue Light und Heavy AT Slot eingefügt

-Sperrabfragen für die Einzeln AT Werfer

-Taru Last und Taru Bank Heli endfernt 

-Beampunkte angepasst an Schlachtort

-Verfügbare Flaggen an Schlachtort angepasst