### PR TITLE
Update Beamsystem

### DIFF
--- a/OPT_mission.Altis/beam/functions/fnc_beam.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_beam.sqf
@@ -6,6 +6,9 @@
 * Author:
 * James
 *
+* Edit by:
+* Manu
+*
 * Arguments:
 * 0: <NUMBER> current selected index of listbox control
 *

--- a/OPT_mission.Altis/beam/functions/fnc_beam.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_beam.sqf
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Description:
 * Teleport player and their vehicle to selected destination.
 * Check for truce time and level of teleport location.
@@ -47,16 +47,34 @@ private _arry = GVAR(box) select _ix;
 private _lvl = _arry select 2;
 private _beam_pos = _arry select 0;
 
-//Zeitabgelaufen check -> oder lvl gleich -1 (Marinebasis)
-if (GVARMAIN(missionStarted) and _lvl != -1) exitWith 
+/* kBF = kein Beamfahrzeug */
+private _kBF = true;
+
+/* prevents beaming to beampoints with level > 0 after mission start if dialog was opened before */
+if (GVARMAIN(missionStarted) and _lvl != -1) then
 { 
-    ["Beamsystem", "Das System steht nur während der Waffenruhe zur Verfügung!", "red"] call EFUNC(gui,message);
-    closeDialog 0;
+    _beamfrei = false;
+    
+    ["Beamsystem", "Dieser Beampunkt steht nur während der Waffenruhe zur Verfügung!", "red"] call EFUNC(gui,message);
 };
 
 if ((typeOf vehicle player) in GVAR(heavy_vehicles)) then 
 {
     _SF = true;
+};
+
+/* sets _kBF to false if used vehicle is listed in GVAR(beam_vehicles) */
+if ((typeOf vehicle player) in GVAR(beam_vehicles)) then
+{
+	_kBF = false;
+};
+
+/* denies beaming after mission start for vehicles not listed in GVAR(beam_vehicles) */
+if ( GVARMAIN(missionStarted) and _kBF and (vehicle player != player)) then
+{
+	_beamfrei = false;
+	
+	["Beamsystem", "Das System steht nur noch für spezielle Beamfahrzeuge zur Verfügung!", "red"] call EFUNC(gui,message);
 };
 
 // Schwere Fahrzeuge zum Beamziel klein Stufe 3 verneinen
@@ -107,9 +125,6 @@ if (_beamfrei) then
 };
 
 closeDialog 0;
-
-
-
 
 
 

--- a/OPT_mission.Altis/beam/functions/fnc_beam.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_beam.sqf
@@ -50,8 +50,8 @@ private _arry = GVAR(box) select _ix;
 private _lvl = _arry select 2;
 private _beam_pos = _arry select 0;
 
-/* kBF = kein Beamfahrzeug */
-private _kBF = true;
+/* used for checking beam permissions after mission start */
+private _isBeamInMissionForbidden = true;
 
 /* prevents beaming to beampoints with level > 0 after mission start if dialog was opened before */
 if (GVARMAIN(missionStarted) and _lvl != -1) then
@@ -66,14 +66,14 @@ if ((typeOf vehicle player) in GVAR(heavy_vehicles)) then
     _SF = true;
 };
 
-/* sets _kBF to false if used vehicle is listed in GVAR(beam_vehicles) */
+/* sets _isBeamInMissionForbidden to false if used vehicle is listed in GVAR(beam_vehicles) */
 if ((typeOf vehicle player) in GVAR(beam_vehicles)) then
 {
-	_kBF = false;
+	_isBeamInMissionForbidden = false;
 };
 
 /* denies beaming after mission start for vehicles not listed in GVAR(beam_vehicles) */
-if ( GVARMAIN(missionStarted) and _kBF and (vehicle player != player)) then
+if ( GVARMAIN(missionStarted) and _isBeamInMissionForbidden and (vehicle player != player)) then
 {
 	_beamfrei = false;
 	

--- a/OPT_mission.Altis/beam/functions/fnc_onloaddialog.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_onloaddialog.sqf
@@ -7,6 +7,9 @@
 * Author:
 * Lord
 *
+* Edit by:
+* Manu
+*
 * Arguments:
 * None
 *

--- a/OPT_mission.Altis/beam/functions/fnc_onloaddialog.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_onloaddialog.sqf
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Description:
 * initialize beam dialog and fill listbox with available options
 * if component is disabled, only options with level -1 are available

--- a/OPT_mission.Altis/beam/functions/fnc_onloaddialog.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_onloaddialog.sqf
@@ -29,6 +29,7 @@
 * Example:
 * [] call EFUNC(beam,onLoadDialog);
 */
+
 #include "script_component.hpp"
 
 /* PARAMS */
@@ -36,13 +37,14 @@
 /* VALIDATION */
 
 /* CODE BODY */
+
 disableSerialization;
 
 private _display = findDisplay DIALOG_BEAM_IDD;
 private _lb = _display displayCtrl DIALOG_BEAM_LB_IDC;
 
-//Zeitabgelaufen check
 private _orte = [];
+
 if (PLAYER_SIDE == east) then
 {
     _orte = GVAR(locations_east);

--- a/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
@@ -65,7 +65,7 @@ GVAR(locations_west) =
     [[8570,0,7349], "FOB", 0],
 
        [[4925.6323,341.19653,21895.656], "1 - Throns castel",0], // 1 - Throns_castel
-	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",0], // 2 - Oreokastro
+	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",-1], // 2 - Oreokastro
 	   [[4910.3472,197.1022,19458.254], "3 - Waffenlager Nord West",0], // 3 - Waffenlager_Nord_West
 	   [[3360.3782,67.56945,18310.93], "4 - Villa Constans",0], // 4 - Villa_Constans
 
@@ -158,7 +158,7 @@ GVAR(locations_east) =
     [[13769,0,6378], "FOB", 0],
 	
         [[4925.6323,341.19653,21895.656], "1 - Throns castel",0], // 1 - Throns_castel
-	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",0], // 2 - Oreokastro
+	   [[4582.2017,299.6069,21385.365], "2 - Oreokastro",-1], // 2 - Oreokastro
 	   [[4910.3472,197.1022,19458.254], "3 - Waffenlager Nord West",0], // 3 - Waffenlager_Nord_West
 	   [[3360.3782,67.56945,18310.93], "4 - Villa Constans",0], // 4 - Villa_Constans
 

--- a/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
@@ -275,11 +275,24 @@ GVAR(heavy_vehicles) =
 /* vehicles usable for beaming after mission start */
 GVAR(beam_vehicles) =
 [
-	"OPT_B_Truck_01_medical_F", 		//HEMTT Medic
-	"OPT_B_Quadbike_01_F",			//Quadbike NATO
-	
-	"OPT_O_Truck_03_medical_F",		//Tempest Medic
-	"OPT_O_Quadbike_01_F"			//Quadbike CSAT
+	//BLUFOR
+	"OPT_B_Truck_01_covered_F",						//HEMTT Abgedeckt
+	"OPT_B_Truck_01_Repair_F",						//HEMTT Reparatur
+	"OPT_B_Truck_01_medical_F", 					//HEMTT Medic
+	"OPT_B_Truck_01_transport_F",					//HEMTT
+	"OPT_B_Quadbike_01_F",							//Quadbike NATO
+	//OPFOR hextarn
+	"OPT_O_Truck_03_covered_F",						//Tempest Abgedeckt
+	"OPT_O_Truck_03_repair_F",						//Tempest Reparatur
+	"OPT_O_Truck_03_medical_F",						//Tempest Medic
+	"OPT_O_Truck_03_transport_F",					//Tempest
+	"OPT_O_Quadbike_01_F",							//Quadbike CSAT
+	//OPFOR tropentarn
+	"OPT_O_T_Truck_03_covered_ghex_F",				//Tempest Abgedeckt
+	"OPT_O_T_Truck_03_repair_ghex_F",				//Tempest Reparatur
+	"OPT_O_T_Truck_03_medical_ghex_F",				//Tempest Medic
+	"OPT_O_T_Truck_03_transport_ghex_F",			//Tempest
+	"OPT_O_T_Quadbike_01_ghex_F"					//Quadbike CSAT
 ];	
 
 /* List of triggers in Editor for beam functionality */

--- a/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Altis/beam/functions/fnc_setup_beamorte.sqf
@@ -7,6 +7,9 @@
 * Author:
 * Lord & James
 *
+* Edit by:
+* Manu
+*
 * Arguments:
 * None
 *
@@ -24,11 +27,25 @@
 *
 * Sideeffects:
 * Define global variables
-* GVAR(locations_west), GVAR(locations_east), GVAR(heavy_vehicles), GVAR(beam_trigger) 
+* GVAR(locations_west), GVAR(locations_east), GVAR(heavy_vehicles), GVAR(beam_vehicles), GVAR(beam_trigger) 
 *
 * Example:
 * [parameter] call EFUNC(fnc_setup_beamOrte.sqf);
+*
+* Usage:
+* Position=[0, 0, 0] 
+* Name = "ABC"
+* Level = {-1; 0; 1; 2; 3}
+* [[Position], Name, Level]
+* 
+* Level:
+* -1 = available after mission start for vehicles defined in GVAR(beam_vehicles) [see below]
+* 0 = not available
+* 1 = infantry only
+* 2 = infantry + light vehicles
+* 3 = infantry + light vehicles + heavy vehicles
 */
+
 #include "script_component.hpp"
 
 /* PARAMS */
@@ -38,14 +55,7 @@
 /* CODE BODY */
 
 
-// Position=[0, 0, 0]
-// Name = "ABC"
-// Stufe = -1-0-1-2-3 // -1 nach Waffenruhe wählbar, 0 Nicht Wählbar,  1 Inf,  2 inf + leichte Fahrzeuge,  3 inf + Schwere Fahrzeuge
-//
-// Bsp [[Position], Name, Stufe], 
-
-
-//West
+//BLUFOR
 GVAR(locations_west) =
 [
     [[3723,0,17576], "Landung_alpha", 0],
@@ -138,7 +148,7 @@ GVAR(locations_west) =
 	   [[25420.861,10.028322,20338.611], "62 - Refinery",0] // 62 - Refinery
 ];
 
-//East
+//OPFOR
 GVAR(locations_east) =
 [
     [[7282,0,10998], "Landung_alpha", 0],
@@ -262,6 +272,15 @@ GVAR(heavy_vehicles) =
 	"OPT4_B_LSV_01_AT_F"
  ];
 
+/* vehicles usable for beaming after mission start */
+GVAR(beam_vehicles) =
+[
+	"OPT_B_Truck_01_medical_F", 		//HEMTT Medic
+	"OPT_B_Quadbike_01_F",			//Quadbike NATO
+	
+	"OPT_O_Truck_03_medical_F",		//Tempest Medic
+	"OPT_O_Quadbike_01_F"			//Quadbike CSAT
+];	
 
 /* List of triggers in Editor for beam functionality */
 GVAR(beam_trigger) = 


### PR DESCRIPTION
Wie gestern in der EL-Sitzung festgelegt ist hier nun die Umsetzung des Beamens nach Waffenruhe mit ausgewählten Fahrzeugen.
Es kann im Setup festgelegt werden, welche Fahrzeuge dafür nutzbar sind, aktuell sind es die Quads sowie die Sanitätstrucks beider Fraktionen.
Um nach der Waffenruhe beamen zu können, muss der gewünschte Beampunkt auf Level -1 gesetzt werden, da ansonsten keine Anzeige des Punktes im Dialog erfolgt.

Zudem wurden ein paar Formfehler korrigiert und die Beschreibung verbessert

PS: Ich hoffe mal, dass das so stimmt mit GitHub, ist mein erster Versuch ^^