### PR TITLE
CBA Settings angeglichen&aufgeräumt + TFAR Frequenz-Fix

### DIFF
--- a/OPT_mission.Altis/cba_settings.sqf
+++ b/OPT_mission.Altis/cba_settings.sqf
@@ -4,7 +4,6 @@ force ace_common_checkPBOsAction = 2;
 force ace_common_checkPBOsCheckAll = true;
 force ace_common_checkPBOsWhitelist = "[""CLib"",""Streamator"",""PerformanceMonitor"", ""opt""]";
 force ace_noradio_enabled = true;
-ace_parachute_hideAltimeter = false;
 
 // ACE BenutzeroberflÃ¤che
 force ace_ui_allowSelectiveUI = true;
@@ -20,8 +19,6 @@ force ace_cookoff_probabilityCoef = 0.2;
 force ace_advanced_throwing_enabled = true;
 force ace_advanced_throwing_enablePickUp = true;
 force ace_advanced_throwing_enablePickUpAttached = true;
-ace_advanced_throwing_showMouseControls = false;
-ace_advanced_throwing_showThrowArc = false;
 
 // ACE Fingerzeig
 force ace_finger_enabled = true;
@@ -86,9 +83,6 @@ force ace_respawn_savePreDeathGear = true;
 force ace_viewdistance_enabled = true;
 force ace_viewdistance_limitViewDistance = 4000;
 force ace_viewdistance_objectViewDistanceCoeff = 0;
-ace_viewdistance_viewDistanceAirVehicle = 8;
-ace_viewdistance_viewDistanceLandVehicle = 8;
-ace_viewdistance_viewDistanceOnFoot = 8;
 
 // ACE Sprengstoffe
 force ace_explosives_explodeOnDefuse = false;
@@ -96,11 +90,11 @@ force ace_explosives_punishNonSpecialists = false;
 force ace_explosives_requireSpecialist = false;
 
 // ACE Uncategorized
+force ace_fastroping_requireRopeItems = false;
 force ace_microdagr_mapDataAvailable = 0;
 force ace_microdagr_waypointPrecision = 3;
 
 // ACE Waffen
-ace_common_persistentLaserEnabled = true;
 force ace_laserpointer_enabled = true;
 
 // ACE Wetter
@@ -119,10 +113,18 @@ force ace_spectator_enableAI = false;
 force ace_spectator_restrictModes = 0;
 force ace_spectator_restrictVisions = 0;
 
+// CBA Waffen
+force cba_disposable_replaceDisposableLauncher = true;
+
+// DUI - Squad Radar - Radar
+diwako_dui_radar_sqlFirst = true; // Recommended/Default , but not enforced
+
 // OPT Feldreparatur
 force DEFAULT_FIELDREPAIR_EACH_HARDPART_TIME = 30;
 force DEFAULT_FIELDREPAIR_EACH_PART_TIME = 15;
 force DEFAULT_FIELDREPAIR_MAX_REP_TIME = 240;
+force DEFAULT_FREE_REFUELS = 1;
+force DEFAULT_FREE_REFUELS_DURATION = 60;
 force DEFAULT_FREE_REPAIRS = 1;
 force DEFAULT_FULLREPAIR_LENGTH = 60;
 force DEFAULT_REPAIR_TRUCK_USES = 10;
@@ -215,6 +217,7 @@ force TFAR_AICanHearPlayer = false;
 force TFAR_AICanHearSpeaker = false;
 force TFAR_defaultIntercomSlot = 0;
 force TFAR_enableIntercom = true;
+force TFAR_experimentalVehicleIsolation = true;
 force TFAR_fullDuplex = true;
 force TFAR_giveLongRangeRadioToGroupLeaders = false;
 force TFAR_giveMicroDagrToSoldier = true;
@@ -222,6 +225,7 @@ force TFAR_givePersonalRadioToRegularSoldier = false;
 force TFAR_globalRadioRangeCoef = 1.5;
 force TFAR_instantiate_instantiateAtBriefing = false;
 force TFAR_objectInterceptionEnabled = true;
+force TFAR_objectInterceptionStrength = 400;
 force tfar_radiocode_east = "_opfor";
 force tfar_radiocode_independent = "_independent";
 force tfar_radiocode_west = "_bluefor";
@@ -252,3 +256,4 @@ force TFAR_takingRadio = 2;
 force TFAR_Teamspeak_Channel_Name = "2302";
 force TFAR_Teamspeak_Channel_Password = "war";
 force tfar_terrain_interception_coefficient = 1;
+force TFAR_voiceCone = true;

--- a/OPT_mission.Altis/cba_settings_war.sqf
+++ b/OPT_mission.Altis/cba_settings_war.sqf
@@ -4,7 +4,6 @@ force ace_common_checkPBOsAction = 2;
 force ace_common_checkPBOsCheckAll = true;
 force ace_common_checkPBOsWhitelist = "[""CLib"",""Streamator"",""PerformanceMonitor"", ""opt""]";
 force ace_noradio_enabled = true;
-ace_parachute_hideAltimeter = false;
 
 // ACE BenutzeroberflÃ¤che
 force ace_ui_allowSelectiveUI = true;
@@ -20,8 +19,6 @@ force ace_cookoff_probabilityCoef = 0.2;
 force ace_advanced_throwing_enabled = true;
 force ace_advanced_throwing_enablePickUp = true;
 force ace_advanced_throwing_enablePickUpAttached = true;
-ace_advanced_throwing_showMouseControls = false;
-ace_advanced_throwing_showThrowArc = false;
 
 // ACE Fingerzeig
 force ace_finger_enabled = true;
@@ -86,9 +83,6 @@ force ace_respawn_savePreDeathGear = true;
 force ace_viewdistance_enabled = true;
 force ace_viewdistance_limitViewDistance = 4000;
 force ace_viewdistance_objectViewDistanceCoeff = 0;
-ace_viewdistance_viewDistanceAirVehicle = 8;
-ace_viewdistance_viewDistanceLandVehicle = 8;
-ace_viewdistance_viewDistanceOnFoot = 8;
 
 // ACE Sprengstoffe
 force ace_explosives_explodeOnDefuse = false;
@@ -101,7 +95,6 @@ force ace_microdagr_mapDataAvailable = 0;
 force ace_microdagr_waypointPrecision = 3;
 
 // ACE Waffen
-ace_common_persistentLaserEnabled = true;
 force ace_laserpointer_enabled = true;
 
 // ACE Wetter
@@ -124,8 +117,7 @@ force ace_spectator_restrictVisions = 0;
 force cba_disposable_replaceDisposableLauncher = true;
 
 // DUI - Squad Radar - Radar
-force diwako_dui_radar_sortType = "none";
-force diwako_dui_radar_sqlFirst = false;
+diwako_dui_radar_sqlFirst = true; // Recommended/Default , but not enforced
 
 // OPT Feldreparatur
 force DEFAULT_FIELDREPAIR_EACH_HARDPART_TIME = 30;
@@ -134,7 +126,7 @@ force DEFAULT_FIELDREPAIR_MAX_REP_TIME = 240;
 force DEFAULT_FREE_REFUELS = 1;
 force DEFAULT_FREE_REFUELS_DURATION = 60;
 force DEFAULT_FREE_REPAIRS = 1;
-force DEFAULT_FULLREPAIR_LENGTH = 120;
+force DEFAULT_FULLREPAIR_LENGTH = 60;
 force DEFAULT_REPAIR_TRUCK_USES = 10;
 
 // OPT GPS
@@ -240,12 +232,12 @@ force tfar_radiocode_west = "_bluefor";
 force tfar_radioCodesDisabled = false;
 force TFAR_SameLRFrequenciesForSide = true;
 force TFAR_SameSRFrequenciesForSide = true;
-force TFAR_setting_defaultFrequencies_lr_east = "40,50,60,41,42,43,51,61,62";
+force TFAR_setting_defaultFrequencies_lr_east = "41,42,43,44,45,46,47,48,49";
 force TFAR_setting_defaultFrequencies_lr_independent = "";
-force TFAR_setting_defaultFrequencies_lr_west = "41,42,43,44,45,46,47,48,49";
-force TFAR_setting_defaultFrequencies_sr_east = "41,42,43,60,61,62,50,51";
+force TFAR_setting_defaultFrequencies_lr_west = "40,50,60,41,42,43,51,61,62";
+force TFAR_setting_defaultFrequencies_sr_east = "71,72,73,74,75,76,77,78";
 force TFAR_setting_defaultFrequencies_sr_independent = "";
-force TFAR_setting_defaultFrequencies_sr_west = "71,72,73,74,75,76,77,78";
+force TFAR_setting_defaultFrequencies_sr_west = "41,42,43,60,61,62,50,51";
 force TFAR_setting_DefaultRadio_Airborne_east = "TFAR_mr6000l";
 force TFAR_setting_DefaultRadio_Airborne_Independent = "TFAR_anarc164";
 force TFAR_setting_DefaultRadio_Airborne_West = "TFAR_anarc210";


### PR DESCRIPTION
Habe von Oppa die aktuellsten Settings bekommen. Habe sie kurz verglichen (Compare with ...) und offensichtlich falsche sowie versehentliche Diskrepanzen entfernt und angeglichen.
Dabei waren dann auch die offensichtlich falschen SR/LR-Frequenzlisten für die Schlacht-Settings gefunden, womit das Problem in Zukunft gelöst sein sollte :) .

Ist erstmal nur ein Angleichen/Fix. Lohnt sich aber, die Settings nochmal im Detail anzuschauen in Bezug auf: Was muss zwingend gesetzt sein, damit alle das gleiche Spielerlebnis haben (keine unfairen Vorteile), aber gleichzeitig den Spielern Freiheiten bei ihren UI-Settings etc. lässt (z.B. DUI-Konfig).