### PR TITLE
GUI-Message improvements

### DIFF
--- a/OPT_mission.Altis/gui/config/rsc_titles.hpp
+++ b/OPT_mission.Altis/gui/config/rsc_titles.hpp
@@ -7,7 +7,7 @@ class APP(message_1) {
     w = GUI_MSG_W;
     h = GUI_MSG_H;
     fade = 1;
-    duration = 15;
+    duration = 7;
     onLoad = QUOTE(with missionnameSpace do {disableSerialization; GVAR(msg_cur) - [_this select 0];GVAR(msg_cur) pushBack (_this select 0);};);
     class controls {
         class background : RSC(BaseText) {

--- a/OPT_mission.Altis/gui/functions/fnc_getguix.sqf
+++ b/OPT_mission.Altis/gui/functions/fnc_getguix.sqf
@@ -1,0 +1,29 @@
+/**
+ * Author: form
+ * returns X-coordinate based on messagetype and left/right CBA-setting
+ *
+ * Arguments:
+ * 0: <NUMBER> GUI-IDC
+ *
+ * Return Value:
+ * X-Coordinate of left border for the messagebox elements
+ *
+ * Example:
+ * _msgboxPos set [0, IDC_MSG_background call FUNC(getguix)];
+ *
+ */
+
+#include "script_component.hpp"
+
+params ["_idc"];
+
+private _return = -1;
+switch (_idc) do
+{
+    case IDC_MSG_background;
+    case IDC_MSG_stripe:        { _return = GUI_MSG_X + GUI_MSG_X_DIFF; };
+    case IDC_MSG_header;
+    case IDC_MSG_content:       { _return = GUI_MSG_X + GUI_MSG_COL + GUI_MSG_X_DIFF; };
+    default                     { _return = -1 };
+};
+_return;

--- a/OPT_mission.Altis/gui/functions/fnc_initcbasettings.sqf
+++ b/OPT_mission.Altis/gui/functions/fnc_initcbasettings.sqf
@@ -1,0 +1,36 @@
+/**
+* Author: James
+* initialize CBA settings
+*
+* Arguments:
+* None
+*
+* Return Value:
+* None
+*
+* Example:
+* [] call fnc_initCBASettings.sqf;
+*
+*/
+#include "script_component.hpp"
+
+[
+    QGVAR(right), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "CHECKBOX", // setting type
+        [
+            "Meldungen am rechten Bildschirmrand",
+            "GUI-Meldungen am rechten anstatt linken Bildschirmrand anzeigen"], // Pretty name shown inside the ingame settings menu. Can be stringtable entry. 
+    ["OPT", "GUI"], // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    true, // data for this setting: [min, max, default, number of shown trailing decimals]
+    0, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        if (GVAR(right)) then
+        {
+            GUI_MSG_X_DIFF = (safeZoneW + safeZoneX - GUI_MSG_W - GUI_DLG_W) - (safezoneX + GUI_DLG_W);
+        }
+        else
+        {
+            GUI_MSG_X_DIFF = 0;
+        };
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;

--- a/OPT_mission.Altis/gui/functions/fnc_message.sqf
+++ b/OPT_mission.Altis/gui/functions/fnc_message.sqf
@@ -18,19 +18,6 @@
 
 #include "script_component.hpp"
 
-getGuiX = { // input: GUI-IDC --> output: X-coordinate (based on left/right CBA-setting)
-    private _return = -1;
-    switch (_this) do
-    {
-        case IDC_MSG_background;
-        case IDC_MSG_stripe:        { _return = GUI_MSG_X + GUI_MSG_X_DIFF; };
-        case IDC_MSG_header;
-        case IDC_MSG_content:       { _return = GUI_MSG_X + GUI_MSG_COL + GUI_MSG_X_DIFF; };
-        default                     { _return = -1 };
-    };
-    _return;
-};
-
 If !(hasInterface) exitWith {};
 
 params [
@@ -85,7 +72,7 @@ If (GVAR(msg_cur) isEqualTo []) then {
 
     { // update coordinates of every GUI-IDD because it could have changed (left/right CBA-setting)
         private _pos = ctrlPosition (_display displayCtrl _x);
-        _pos set [0, _x call getGuiX];
+        _pos set [0, _x call FUNC(getguix)];
         (_display displayCtrl _x) ctrlSetPosition _pos;
         (_display displayCtrl _x) ctrlCommit 0;
     } forEach [IDC_MSG_background, IDC_MSG_stripe, IDC_MSG_header, IDC_MSG_content];
@@ -138,7 +125,7 @@ If (GVAR(msg_cur) isEqualTo []) then {
                     private _display = _x;
                     {
                         private _pos = ctrlPosition (_display displayCtrl _x);
-                        (_display displayCtrl _x) ctrlSetPosition [_x call getGuiX, ((_pos select 1) + _move)];
+                        (_display displayCtrl _x) ctrlSetPosition [_x call FUNC(getguix), ((_pos select 1) + _move)];
                         (_display displayCtrl _x) ctrlCommit MOVINGTIME;
                     }forEach [IDC_MSG_background, IDC_MSG_stripe, IDC_MSG_header, IDC_MSG_content];
                 } forEach GVAR(msg_cur);
@@ -154,7 +141,7 @@ If (GVAR(msg_cur) isEqualTo []) then {
 
                 { // update coordinates of every GUI-IDD because it could have changed (left/right CBA-setting)
                     private _pos = ctrlPosition (_display displayCtrl _x);
-                    _pos set [0, _x call getGuiX];
+                    _pos set [0, _x call FUNC(getguix)];
                     (_display displayCtrl _x) ctrlSetPosition _pos;
                     (_display displayCtrl _x) ctrlCommit 0;
                 } forEach [IDC_MSG_background, IDC_MSG_stripe, IDC_MSG_header, IDC_MSG_content];
@@ -166,16 +153,16 @@ If (GVAR(msg_cur) isEqualTo []) then {
                     /// content & background
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_background);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_content)) select 3];
-                    _curPos set [0, IDC_MSG_background call getGuiX];
+                    _curPos set [0, IDC_MSG_background call FUNC(getguix)];
                     (_display displayCtrl IDC_MSG_background) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_background) ctrlCommit 0;
-                    _curPos set [0, IDC_MSG_content call getGuiX];
+                    _curPos set [0, IDC_MSG_content call FUNC(getguix)];
                     (_display displayCtrl IDC_MSG_content) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_content) ctrlCommit 0;
                     /// color
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_stripe);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_content)) select 3];
-                    _curPos set [0, IDC_MSG_stripe call getGuiX];
+                    _curPos set [0, IDC_MSG_stripe call FUNC(getguix)];
                     (_display displayCtrl IDC_MSG_stripe) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_stripe) ctrlCommit 0;
                 };
@@ -183,13 +170,13 @@ If (GVAR(msg_cur) isEqualTo []) then {
                     /// background
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_background);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_header)) select 3];
-                    _curPos set [0, IDC_MSG_background call getGuiX];
+                    _curPos set [0, IDC_MSG_background call FUNC(getguix)];
                     (_display displayCtrl IDC_MSG_background) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_background) ctrlCommit 0;
                     /// color
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_stripe);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_header)) select 3];
-                    _curPos set [0, IDC_MSG_stripe call getGuiX];
+                    _curPos set [0, IDC_MSG_stripe call FUNC(getguix)];
                     (_display displayCtrl IDC_MSG_stripe) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_stripe) ctrlCommit 0;
                 };

--- a/OPT_mission.Altis/gui/functions/fnc_message.sqf
+++ b/OPT_mission.Altis/gui/functions/fnc_message.sqf
@@ -18,6 +18,19 @@
 
 #include "script_component.hpp"
 
+getGuiX = { // input: GUI-IDC --> output: X-coordinate (based on left/right CBA-setting)
+    private _return = -1;
+    switch (_this) do
+    {
+        case IDC_MSG_background;
+        case IDC_MSG_stripe:        { _return = GUI_MSG_X + GUI_MSG_X_DIFF; };
+        case IDC_MSG_header;
+        case IDC_MSG_content:       { _return = GUI_MSG_X + GUI_MSG_COL + GUI_MSG_X_DIFF; };
+        default                     { _return = -1 };
+    };
+    _return;
+};
+
 If !(hasInterface) exitWith {};
 
 params [
@@ -70,6 +83,13 @@ If (GVAR(msg_cur) isEqualTo []) then {
     (_display displayCtrl IDC_MSG_header) ctrlSetText _title;
     (_display displayCtrl IDC_MSG_content) ctrlSetStructuredText (parseText _content);
 
+    { // update coordinates of every GUI-IDD because it could have changed (left/right CBA-setting)
+        private _pos = ctrlPosition (_display displayCtrl _x);
+        _pos set [0, _x call getGuiX];
+        (_display displayCtrl _x) ctrlSetPosition _pos;
+        (_display displayCtrl _x) ctrlCommit 0;
+    } forEach [IDC_MSG_background, IDC_MSG_stripe, IDC_MSG_header, IDC_MSG_content];
+
     If (_title isEqualTo "") then {
         /// content & background
         private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_background);
@@ -118,7 +138,7 @@ If (GVAR(msg_cur) isEqualTo []) then {
                     private _display = _x;
                     {
                         private _pos = ctrlPosition (_display displayCtrl _x);
-                        (_display displayCtrl _x) ctrlSetPosition [_pos select 0, ((_pos select 1) + _move)];
+                        (_display displayCtrl _x) ctrlSetPosition [_x call getGuiX, ((_pos select 1) + _move)];
                         (_display displayCtrl _x) ctrlCommit MOVINGTIME;
                     }forEach [IDC_MSG_background, IDC_MSG_stripe, IDC_MSG_header, IDC_MSG_content];
                 } forEach GVAR(msg_cur);
@@ -131,6 +151,14 @@ If (GVAR(msg_cur) isEqualTo []) then {
                 };
                 format[QAPP(message_%1), GVAR(msg_cur_ID)] cutRsc [format[QAPP(message_%1), GVAR(msg_cur_ID)], "PLAIN"];
                 private _display = GVAR(msg_cur) select (count (GVAR(msg_cur)) - 1);
+
+                { // update coordinates of every GUI-IDD because it could have changed (left/right CBA-setting)
+                    private _pos = ctrlPosition (_display displayCtrl _x);
+                    _pos set [0, _x call getGuiX];
+                    (_display displayCtrl _x) ctrlSetPosition _pos;
+                    (_display displayCtrl _x) ctrlCommit 0;
+                } forEach [IDC_MSG_background, IDC_MSG_stripe, IDC_MSG_header, IDC_MSG_content];
+
                 (_display displayCtrl IDC_MSG_stripe) ctrlSetBackGroundColor _color;
                 (_display displayCtrl IDC_MSG_header) ctrlSetText _title;
                 (_display displayCtrl IDC_MSG_content) ctrlSetStructuredText (parseText _content);
@@ -138,13 +166,16 @@ If (GVAR(msg_cur) isEqualTo []) then {
                     /// content & background
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_background);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_content)) select 3];
+                    _curPos set [0, IDC_MSG_background call getGuiX];
                     (_display displayCtrl IDC_MSG_background) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_background) ctrlCommit 0;
+                    _curPos set [0, IDC_MSG_content call getGuiX];
                     (_display displayCtrl IDC_MSG_content) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_content) ctrlCommit 0;
                     /// color
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_stripe);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_content)) select 3];
+                    _curPos set [0, IDC_MSG_stripe call getGuiX];
                     (_display displayCtrl IDC_MSG_stripe) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_stripe) ctrlCommit 0;
                 };
@@ -152,11 +183,13 @@ If (GVAR(msg_cur) isEqualTo []) then {
                     /// background
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_background);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_header)) select 3];
+                    _curPos set [0, IDC_MSG_background call getGuiX];
                     (_display displayCtrl IDC_MSG_background) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_background) ctrlCommit 0;
                     /// color
                     private _curPos = ctrlPosition(_display displayCtrl IDC_MSG_stripe);
                     _curPos set [3, (ctrlPosition(_display displayCtrl IDC_MSG_header)) select 3];
+                    _curPos set [0, IDC_MSG_stripe call getGuiX];
                     (_display displayCtrl IDC_MSG_stripe) ctrlSetPosition _curPos;
                     (_display displayCtrl IDC_MSG_stripe) ctrlCommit 0;
                 };

--- a/OPT_mission.Altis/gui/setup.hpp
+++ b/OPT_mission.Altis/gui/setup.hpp
@@ -1,1 +1,1 @@
-#define MOVINGTIME (3 * _move)
+#define MOVINGTIME (1 * _move)

--- a/OPT_mission.Altis/gui/xeh_preinit.sqf
+++ b/OPT_mission.Altis/gui/xeh_preinit.sqf
@@ -10,3 +10,6 @@ ADDON = true;
 
 GVAR(msg_waiting) = [];
 GVAR(msg_cur) = [];
+
+// CBA settings
+[] call FUNC(initCBASettings);

--- a/OPT_mission.Altis/gui/xeh_prep.hpp
+++ b/OPT_mission.Altis/gui/xeh_prep.hpp
@@ -1,2 +1,3 @@
 PREP(initCBASettings);
 PREP(message);
+PREP(getguix);

--- a/OPT_mission.Altis/gui/xeh_prep.hpp
+++ b/OPT_mission.Altis/gui/xeh_prep.hpp
@@ -1,2 +1,2 @@
-
+PREP(initCBASettings);
 PREP(message);

--- a/OPT_mission.Altis/warehouse/functions/fnc_spawnvehicle.sqf
+++ b/OPT_mission.Altis/warehouse/functions/fnc_spawnvehicle.sqf
@@ -1,4 +1,4 @@
-/**
+﻿/**
 * Author: James
 * spawn a vehicle 
 *
@@ -113,7 +113,9 @@ for "_i" from 0 to _spiralMaxPoints step 1 do
 if (_placed < 1) then
 {
 	deleteVehicle _vec;
-	hintSilent "Nicht genug Platz vorhanden!";
+	private _displayName = getText (configFile >> "CfgVehicles" >> _vecType >> "displayName");
+	private _txt = format["Nicht genug Platz für %1 vorhanden!",_displayName];
+	["Bestellung", _txt, "red"] remoteExecCall [QEFUNC(gui,message), _unit, false];
 };
 
 GVAR(spawnInProgress) = false;


### PR DESCRIPTION
Fix für https://github.com/OperationPandoraTrigger/OPT-Server-Mod/issues/39

GUI-Messages (z.B. bei Ausrüstungs-Kauf) 
- überdecken nicht mehr das Mausrad-Menü, da nun auf rechter Bildschirmseite
- bleiben nur noch 7 statt 15 Sekunden sichtbar.
- scrollen 3-fach schneller zur Seite, wenn neue Meldungen kommen.
- zeigen auch an wenn für Bestellungen kein Platz verfügbar ist. Das war vorher per hint gelöst und hat irgendwie auch gar nicht mehr funktioniert.