### PR TITLE
Medical stabilize without abortion

### DIFF
--- a/OPT_mission.Altis/revive/functions/fnc_handlestabilize.sqf
+++ b/OPT_mission.Altis/revive/functions/fnc_handlestabilize.sqf
@@ -112,7 +112,7 @@ sleep 1;
         // -> aktualisiere Fortschrittsbalken
         alive _healer and
         alive _patient and
-        (_healer distance _patient) < 2 and
+//        (_healer distance _patient) < 2 and
         _healer getVariable "FAR_isUnconscious" == 0
 
     }


### PR DESCRIPTION
https://youtu.be/8QytrSGyZ-w?t=8829
Wenn ihr bei 2:27:17 pausiert und euch mit der "."-Taste Bildweise durchskippt, seht ihr das der Patient für 8 Frames lang "verschwindet". Möglicherweise durch Network-Lag o.ä. - Da ich dies bei einem lokalen Test mit 2 Clients nicht nachstellen konnte.

Dieser "Teleport" des Patienten triggert wahrscheinlich die Abbruchbedingung `(_healer distance _patient) < 2`, die unnötigerweise während des Stabilisierens aktiv ist. "Unnötigerweise", da der Patient vorher eh mittels `_patient attachTo [_healer,_offset];` ans Bett gefesselt wird.

Übrigens ist diese Bedingung anscheinend auch schon bei der Endheilung ( https://github.com/OperationPandoraTrigger/OPT-Mission/blob/c80ea1a9c3e9d1f88ff96ef3f33e95ea77b8596e/OPT_mission.Altis/revive/functions/fnc_handlerevive.sqf#L132 ) nachträglich rausgeflogen, da es noch in den Kommentaren auftaucht, aber nicht mehr im Code darunter.