### PR TITLE
beam location limitation extended, waffenruhe-check implemented

### DIFF
--- a/OPT_mission.Tanoa/beam/config/addbeamdialog.hpp
+++ b/OPT_mission.Tanoa/beam/config/addbeamdialog.hpp
@@ -67,24 +67,12 @@ class GVAR(dlg_addbeam)
             idc = 1613;
             style = ST_CENTER + ST_VCENTER;
             text = "Übernehmen"; //--- ToDo: Localize;
-            x = 5.5 * GUI_GRID_W + GUI_GRID_X;
+            x = 16.5 * GUI_GRID_W + GUI_GRID_X;
             y = 15.5 * GUI_GRID_H + GUI_GRID_Y;
             w = 8 * GUI_GRID_W;
             h = 1.5 * GUI_GRID_H;
             sizeEx = (0.023 / (getResolution select 5));
             action = QUOTE([] call FUNC(addBeam););
-        };
-        class RscButton_1713: RscButton
-        {
-            idc = 1713;
-            style = ST_CENTER + ST_VCENTER;
-            text = "Schließen"; //--- ToDo: Localize;
-            x = 27.5 * GUI_GRID_W + GUI_GRID_X;
-            y = 15.5 * GUI_GRID_H + GUI_GRID_Y;
-            w = 8 * GUI_GRID_W;
-            h = 1.5 * GUI_GRID_H;
-            sizeEx = (0.023 / (getResolution select 5));
-            action = "closeDialog 0";
         };
     };
 };

--- a/OPT_mission.Tanoa/beam/functions/fnc_addbeam.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_addbeam.sqf
@@ -19,6 +19,14 @@ disableSerialization;
 private _dialog = uiNamespace getVariable [QGVAR(AddBeamDialog) , displayNull];
 if (_dialog isEqualTo displayNull) exitWith {ERROR_MSG("Fehler beim Aufruf von AddBeamDialog!")};
 
+// Waffenruhe bei Buttonklick schon abgelaufen?
+if (GVARMAIN(missionStarted)) exitWith
+{
+	private _txt = format["Die Waffenruhe war bereits abgelaufen!"];
+	["Beam", _txt, "red"] remoteExecCall [QEFUNC(gui,message), player, false];
+	closeDialog 0;
+};
+
 private _edit = _dialog displayCtrl DIALOG_ADDBEAM_IDC;
 
 private _lineBreak = toString [10];
@@ -31,8 +39,22 @@ private _orte = [];
 
 } foreach (_dialogText splitString _lineBreak);
 
-// Prüfung auf erlaubte Anzahl der Beampunkte. Definiert in beam\setup.hpp
-if (count _orte <= BEAM_MAX_LOCATIONS) then
+// Ermittle die erlaubte Anzahl der
+// Beampunkte (Definiert in beam\setup.hpp)
+// +
+// Anzahl der Flaggen, die dem Gegner für den Angriff zur Auswahl stehen. (Definiert in sectorcontrol\functions\fnc_setup_flagpositions.sqf)
+private _MAX_LOCATIONS = 0;
+if (PLAYER_SIDE == east) then
+{
+	_MAX_LOCATIONS = BEAM_MAX_LOCATIONS + count GVARMAIN(csat_flags_pos);
+}
+else
+{
+	_MAX_LOCATIONS = BEAM_MAX_LOCATIONS + count GVARMAIN(nato_flags_pos);
+};
+
+// Prüfung auf erlaubte Anzahl der Beampunkte.
+if (count _orte <= _MAX_LOCATIONS) then
 {
 	// write updated positions back to global variables
 	if (PLAYER_SIDE == east) then
@@ -59,6 +81,8 @@ if (count _orte <= BEAM_MAX_LOCATIONS) then
 }
 else
 {
-	private _txt = format["Es dürfen nur %1 Beampunkte angegeben werden!", BEAM_MAX_LOCATIONS];
+	private _txt = format["Es dürfen nur %1 Beampunkte angegeben werden!", _MAX_LOCATIONS];
 	["Beam", _txt, "red"] remoteExecCall [QEFUNC(gui,message), player, false];
 };
+
+closeDialog 0;

--- a/OPT_mission.Tanoa/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_setup_beamorte.sqf
@@ -49,45 +49,10 @@
 #include "script_component.hpp"
 
 //West
-GVAR(locations_west) =
-[
- /*
-    [[11151,0,10123], "Zum Durchgeknallten Taliban 1", 4],
-    [[0,0,0], "Beampunkt 2", 0],
-    [[0,0,0], "Beampunkt 3", 0],
-    [[0,0,0], "Marine Basis",0],
-    [[0,0,0], "FOB", 0],
-
-
-
-	   [[14352,0,8600],"69 - schöne Aussicht",1], //
-	   [[13482,0,9579],"115 - Goldgrube",1], // 
-	   [[13964,0,10011],"84 - alte Mine",1] // 
-
-
-*/
-];
+GVAR(locations_west) = [];
 
 //East
-GVAR(locations_east) =
-[
-/*
-    [[11151,0,10123], "Zum Durchgeknallten Taliban 1", 4],
-    [[0,0,0], "Beampunkt 2", 0],
-    [[0,0,0], "Beampunkt 3", 0],
-    [[0,0,0], "Marine Basis", 0],
-    [[0,0,0], "FOB", 0],
-
-
-
-	   [[13049,0,10656],"04 - Dogana Blueperl",1], // 
-	   [[13763,0,10808],"05 - Checkpoint Bravo",1], //
-	   [[13427,0,11714],"73 - Blueperl Brecheranlage",1], // 
-	   [[13784,0,11900],"71 - Trockendok",1] // 
-
-
-*/       
-];
+GVAR(locations_east) = [];
 
 /* vehicles requiring special clearance for beaming (eg. tanks) */
 GVAR(restricted_vehicles) = 


### PR DESCRIPTION
- [x] Anzahl erlaubter Beampositionen um die Anzahl der Flaggen, die der Gegner zum Angriff zur Auswahl hat, erweitert
- [x] Check auf abgelaufene Waffenruhe im Moment des Button drückens
- [x] Auto-Close des Dialoges und entfernen des nun unnötigem Schließen-Buttons