### PR TITLE
fixed addBeam

### DIFF
--- a/OPT_mission.Tanoa/sectorcontrol/functions/fnc_setup_flagpositions.sqf
+++ b/OPT_mission.Tanoa/sectorcontrol/functions/fnc_setup_flagpositions.sqf
@@ -33,7 +33,9 @@ GVARMAIN(csat_flags_pos) = [
 	   
 ];
 
-
+// Arrays öffentlich machen - Wichtig für fnc_addbeam
+publicVariable QGVARMAIN(nato_flags_pos);
+publicVariable QGVARMAIN(csat_flags_pos);
 
 // erzeuge für alle oben gelisteten Positionen einen Flaggenmast mit korrekter Flagge vom Server aus.
 


### PR DESCRIPTION
Die angreifbaren Flaggenpositionen werden nun Serverweit öffentlich gemacht, damit addBeam die Flaggenanzahl kennt.
Vermutlich hat das auch Auswirkungen auf @GNCLORD-MDB seine
https://github.com/OperationPandoraTrigger/OPT-Mission/blob/tanoa_2020H1/OPT_mission.Tanoa/waffenruhemarker/functions/fnc_markierungen.sqf da hier auch aus einem anderen Modul heraus darauf zugegriffen wird. Hat das evtl. vorher auch nicht funktioniert?
Bitte prüfen!