### PR TITLE
fix JiP

### DIFF
--- a/OPT_mission.Tanoa/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_setup_beamorte.sqf
@@ -1,6 +1,5 @@
 /**
 * Description:
-* setup available beam locations with their respective level
 * setup heavy vehicle classnames
 * setup beam trigger variable names
 *
@@ -8,7 +7,7 @@
 * Lord & James
 *
 * Edit by:
-* Manu
+* Manu & form
 *
 * Arguments:
 * None
@@ -27,7 +26,7 @@
 *
 * Sideeffects:
 * Define global variables
-* GVAR(locations_west), GVAR(locations_east), GVAR(restricted_vehicles), GVAR(beam_vehicles), GVAR(beam_trigger) 
+* GVAR(restricted_vehicles), GVAR(beam_vehicles), GVAR(beam_trigger) 
 *
 * Example:
 * [parameter] call EFUNC(fnc_setup_beamOrte.sqf);
@@ -47,12 +46,6 @@
 */
 
 #include "script_component.hpp"
-
-//West
-GVAR(locations_west) = [];
-
-//East
-GVAR(locations_east) = [];
 
 /* vehicles requiring special clearance for beaming (eg. tanks) */
 GVAR(restricted_vehicles) = 

--- a/OPT_mission.Tanoa/beam/xeh_preinit.sqf
+++ b/OPT_mission.Tanoa/beam/xeh_preinit.sqf
@@ -13,8 +13,8 @@ ADDON = true;
 // define variable with default value!
 // GVAR(...)
 GVAR(box) = []; // contains all available beam positions defined in setup_beamOrte.sqf
-GVAR(locations_west) = []; // contains all beam locations for west
-GVAR(locations_east) = []; // contains all beam locations for east
+if (isNil QGVAR(locations_west)) then { GVAR(locations_west) = []; }; // contains all beam locations for west, only create when not synced by JiP
+if (isNil QGVAR(locations_east)) then { GVAR(locations_east) = []; }; // contains all beam locations for east, only create when not synced by JiP
 GVAR(restricted_vehicles) = []; // contains all restricted vehicle classnames that are only allowed at lvl 3
 GVAR(beam_vehicles) = []; // contains all vehicles usable for beaming after mission start
 GVAR(beam_trigger) = []; // contains all trigger variable names that allow player to open beam dialog


### PR DESCRIPTION
Verhindert das Initialisieren mit leerem Array im PreInit, wenn JiP schon Positionen synchronisiert hatte.