### PR TITLE
addBeam nur noch fuer zusaetzliche beams

### DIFF
--- a/OPT_mission.Tanoa/beam/config/addbeamdialog.hpp
+++ b/OPT_mission.Tanoa/beam/config/addbeamdialog.hpp
@@ -47,7 +47,7 @@ class GVAR(dlg_addbeam)
             font = DEFAULTFONT;
             colorText[] = {1,1,1,1};
             colorBackground[] = {0,0,0,0};
-            text = "Aktuelle Liste aller Beampunkte: (editierbar)<br/>(Einfügen mit STRG+V. Neue Zeile mit SHIFT+ENTER.)<br/>Format: [[Pos_X, 0, Pos_Y], Name, Level]<br/>Level 1: Inf, 2: Inf+KFZ, 3: Alles, 4: Nach Missionsstart";
+            text = "Aktuelle Liste zusätzlicher Beampunkte: (editierbar)<br/>(Einfügen mit STRG+V. Neue Zeile mit SHIFT+ENTER.)<br/>Format: [[Pos_X, 0, Pos_Y], Name, Level]<br/>Level 1: Inf, 2: Inf+KFZ, 3: Alles, 4: Nach Missionsstart";
             x = 6 * GUI_GRID_W + GUI_GRID_X;
             y = 0.5 * GUI_GRID_H + GUI_GRID_Y;
             w = 30 * GUI_GRID_W;

--- a/OPT_mission.Tanoa/beam/functions/fnc_addbeam.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_addbeam.sqf
@@ -39,33 +39,19 @@ private _orte = [];
 
 } foreach (_dialogText splitString _lineBreak);
 
-// Ermittle die erlaubte Anzahl der
-// Beampunkte (Definiert in beam\setup.hpp)
-// +
-// Anzahl der Flaggen, die dem Gegner für den Angriff zur Auswahl stehen. (Definiert in sectorcontrol\functions\fnc_setup_flagpositions.sqf)
-private _MAX_LOCATIONS = 0;
-if (PLAYER_SIDE == east) then
-{
-	_MAX_LOCATIONS = BEAM_MAX_LOCATIONS + count GVARMAIN(csat_flags_pos);
-}
-else
-{
-	_MAX_LOCATIONS = BEAM_MAX_LOCATIONS + count GVARMAIN(nato_flags_pos);
-};
-
-// Prüfung auf erlaubte Anzahl der Beampunkte.
-if (count _orte <= _MAX_LOCATIONS) then
+// Prüfung auf erlaubte Anzahl der Beampunkte (Definiert in beam\setup.hpp)
+if (count _orte <= BEAM_MAX_LOCATIONS) then
 {
 	// write updated positions back to global variables
 	if (PLAYER_SIDE == east) then
 	{
-		GVAR(locations_east) = _orte;
-		publicVariable QGVAR(locations_east);
+		GVAR(custom_beam_east) = _orte;
+		publicVariable QGVAR(custom_beam_east);
 	}
 	else
 	{
-		GVAR(locations_west) = _orte;
-		publicVariable QGVAR(locations_west);
+		GVAR(custom_beam_west) = _orte;
+		publicVariable QGVAR(custom_beam_west);
 	};
 
 	// Log beam position update
@@ -81,7 +67,7 @@ if (count _orte <= _MAX_LOCATIONS) then
 }
 else
 {
-	private _txt = format["Es dürfen nur %1 Beampunkte angegeben werden!", _MAX_LOCATIONS];
+	private _txt = format["Es dürfen nur %1 Beampunkte angegeben werden!", BEAM_MAX_LOCATIONS];
 	["Beam", _txt, "red"] remoteExecCall [QEFUNC(gui,message), player, false];
 };
 

--- a/OPT_mission.Tanoa/beam/functions/fnc_initaddbeamdialog.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_initaddbeamdialog.sqf
@@ -31,11 +31,11 @@ private _orte = [];
 
 if (PLAYER_SIDE == east) then
 {
-    _orte = GVAR(locations_east);
+    _orte = GVAR(custom_beam_east);
 }
 else
 {
-    _orte = GVAR(locations_west);
+    _orte = GVAR(custom_beam_west);
 };
 
 // write positions to edit-ctrl

--- a/OPT_mission.Tanoa/beam/functions/fnc_onloaddialog.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_onloaddialog.sqf
@@ -50,13 +50,11 @@ private _orte = [];
 
 if (PLAYER_SIDE == east) then
 {
-    _orte = GVAR(locations_east);
-
+    _orte = GVAR(locations_east) + GVAR(custom_beam_east);
 }
 else
 {
-    _orte = GVAR(locations_west);
-
+    _orte = GVAR(locations_west) + GVAR(custom_beam_west);
 };
 
 

--- a/OPT_mission.Tanoa/beam/functions/fnc_setup_beamorte.sqf
+++ b/OPT_mission.Tanoa/beam/functions/fnc_setup_beamorte.sqf
@@ -1,5 +1,6 @@
 /**
 * Description:
+* setup available beam locations with their respective level
 * setup heavy vehicle classnames
 * setup beam trigger variable names
 *
@@ -7,7 +8,7 @@
 * Lord & James
 *
 * Edit by:
-* Manu & form
+* Manu
 *
 * Arguments:
 * None
@@ -26,7 +27,7 @@
 *
 * Sideeffects:
 * Define global variables
-* GVAR(restricted_vehicles), GVAR(beam_vehicles), GVAR(beam_trigger) 
+* GVAR(locations_west), GVAR(locations_east), GVAR(restricted_vehicles), GVAR(beam_vehicles), GVAR(beam_trigger) 
 *
 * Example:
 * [parameter] call EFUNC(fnc_setup_beamOrte.sqf);
@@ -46,6 +47,20 @@
 */
 
 #include "script_component.hpp"
+
+//West
+GVAR(locations_west) = [
+	[[6529,0,11111],"44 - Frozens Folterkammer",1],
+	[[8258,0,11148],"52 - Großmeisters Tempel",1],
+	[[8841,0,10210],"54 - Tanuka Mail",1]
+];
+
+//East
+GVAR(locations_east) = [
+	[[8119,0,9406],"06 - Checkpoint Airport",1],
+	[[7444,0,8552],"35 - Kraftwerk",1],
+	[[6040,0,10417],"57 - Sender GT",1]
+];
 
 /* vehicles requiring special clearance for beaming (eg. tanks) */
 GVAR(restricted_vehicles) = 

--- a/OPT_mission.Tanoa/beam/xeh_preinit.sqf
+++ b/OPT_mission.Tanoa/beam/xeh_preinit.sqf
@@ -13,8 +13,10 @@ ADDON = true;
 // define variable with default value!
 // GVAR(...)
 GVAR(box) = []; // contains all available beam positions defined in setup_beamOrte.sqf
-if (isNil QGVAR(locations_west)) then { GVAR(locations_west) = []; }; // contains all beam locations for west, only create when not synced by JiP
-if (isNil QGVAR(locations_east)) then { GVAR(locations_east) = []; }; // contains all beam locations for east, only create when not synced by JiP
+GVAR(locations_west) = []; // contains flag-beam locations for west
+GVAR(locations_east) = []; // contains flag-beam locations for east
+if (isNil QGVAR(custom_beam_west)) then { GVAR(custom_beam_west) = []; }; // contains custom beam locations for west, only create when not synced by JiP
+if (isNil QGVAR(custom_beam_east)) then { GVAR(custom_beam_east) = []; }; // contains custom beam locations for east, only create when not synced by JiP
 GVAR(restricted_vehicles) = []; // contains all restricted vehicle classnames that are only allowed at lvl 3
 GVAR(beam_vehicles) = []; // contains all vehicles usable for beaming after mission start
 GVAR(beam_trigger) = []; // contains all trigger variable names that allow player to open beam dialog

--- a/OPT_mission.Tanoa/sectorcontrol/functions/fnc_setup_flagpositions.sqf
+++ b/OPT_mission.Tanoa/sectorcontrol/functions/fnc_setup_flagpositions.sqf
@@ -8,34 +8,18 @@ east -> Angriffsziel für NATO
 #include "script_component.hpp"
 
 GVARMAIN(nato_flags_pos) = [
-
-// Basis 
-
-
-	   [14352,8600, west,"69 - schöne Aussicht",true], //
-	   [13482,9579, west,"115 - Goldgrube",true], // 
-	   [13964,10011, west,"84 - alte Mine",true] // 
-	   
-    
-
+	[6529,11111, west,"44 - Frozens Folterkammer",true],
+	[8258,11148, west,"52 - Großmeisters Tempel",true],
+	[8841,10210, west,"54 - Tanuka Mail",true]
 ];
 
 GVARMAIN(csat_flags_pos) = [
-
-//Basis 
-
-	   [13049,10656, east,"04 - Dogana Bluepearl",true], // 
-	   [13763,10808, east,"05 - Checkpoint Bravo",true], //
-	   [13427,11714, east,"73 - Bluepearl Brecheranlage",true], // 
-	   [13784,11900, east,"71 - Trockendock",true] // 
-
-
-	   
+	[8119,9406, east,"06 - Checkpoint Airport",true],
+	[7444,8552, east,"35 - Kraftwerk",true],
+	[6040,10417, east,"57 - Sender GT",true]   
 ];
 
-// Arrays öffentlich machen - Wichtig für fnc_addbeam
-publicVariable QGVARMAIN(nato_flags_pos);
-publicVariable QGVARMAIN(csat_flags_pos);
+
 
 // erzeuge für alle oben gelisteten Positionen einen Flaggenmast mit korrekter Flagge vom Server aus.
 


### PR DESCRIPTION
wie besprochen kontrolliert addBeam nun nur noch zusätzliche Beampunkte.
Die Flaggenbeams sind wie bisher in fnc_setup_beamorte.sqf definiert.

Zusätzlich noch die Fahnenorte für Schlacht 8 aus der Rev.2 importiert.