### PR TITLE
Unsichtbare Helipads

### DIFF
--- a/OPT_mission.Tanoa/mission.sqm
+++ b/OPT_mission.Tanoa/mission.sqm
@@ -2321,7 +2321,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=3859;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=0.00091362;
 											class CustomAttributes
 											{
@@ -7188,7 +7188,7 @@ class Mission
 										skill=0.60000002;
 									};
 									id=3996;
-									type="Land_HelipadCircle_F";
+									type="Land_HelipadEmpty_F";
 									atlOffset=20.103439;
 								};
 								class Item2
@@ -7339,7 +7339,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4011;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=0.41162109;
 											class CustomAttributes
 											{
@@ -7379,7 +7379,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4012;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=1.4932079;
 											class CustomAttributes
 											{
@@ -7419,7 +7419,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4013;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=2.4009266;
 										};
 										class Item3
@@ -7496,7 +7496,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4016;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=0.62626839;
 										};
 										class Item5
@@ -23544,7 +23544,7 @@ class Mission
 										skill=0.60000002;
 									};
 									id=4294;
-									type="Land_HelipadCircle_F";
+									type="Land_HelipadEmpty_F";
 									atlOffset=25.217447;
 								};
 								class Item1
@@ -23921,7 +23921,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4316;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=1.426693;
 										};
 										class Item1
@@ -23938,7 +23938,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4317;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=1.5906296;
 											class CustomAttributes
 											{
@@ -23978,7 +23978,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4318;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=0.94545364;
 											class CustomAttributes
 											{
@@ -24018,7 +24018,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4319;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=1.7255955;
 										};
 										class Item4
@@ -24077,7 +24077,7 @@ class Mission
 												skill=0.60000002;
 											};
 											id=4322;
-											type="Land_HelipadCircle_F";
+											type="Land_HelipadEmpty_F";
 											atlOffset=0.24761963;
 											class CustomAttributes
 											{

--- a/OPT_mission.Tanoa/warehouse/functions/fnc_deletevehicle.sqf
+++ b/OPT_mission.Tanoa/warehouse/functions/fnc_deletevehicle.sqf
@@ -15,7 +15,7 @@
 #include "script_component.hpp"
 
 // alle Objekte im Radius von GVAR(saleRadius) Metern um das Pad -> im Idealfall nur das zu verkaufende Fahrzeug
-_spawnpos = nearestObject [player, "Land_HelipadCircle_F"];
+_spawnpos = nearestObject [player, "Land_HelipadEmpty_F"];
 _objs = nearestObjects [_spawnpos, ["AllVehicles", "Thing"], GVAR(orderSpawnRadius)];
 
 // now delete

--- a/OPT_mission.Tanoa/warehouse/functions/fnc_sendvehicleorder.sqf
+++ b/OPT_mission.Tanoa/warehouse/functions/fnc_sendvehicleorder.sqf
@@ -46,7 +46,7 @@ if (_unitCost > (_side_Budget + GVARMAIN(dispo))) exitWith {
     ["Budget unzureichend", _txt, "red"] call EFUNC(gui,message);
 };
 
-private _spawnObj = nearestObject [player, "Land_HelipadCircle_F"];
+private _spawnObj = nearestObject [player, "Land_HelipadEmpty_F"];
 
 [player, _unitType, _spawnObj, _unitCost] remoteExec [QFUNC(spawnVehicle), 2, false]; // sheduled environment
 //systemChat format ["VT:%1 SO:%2 OSR:%3",_unitType, _spawnObj,(position _spawnObj)];

--- a/OPT_mission.Tanoa/warehouse/functions/fnc_vehicleorder.sqf
+++ b/OPT_mission.Tanoa/warehouse/functions/fnc_vehicleorder.sqf
@@ -123,7 +123,7 @@ if (count GVAR(orderDialogObjects) != 0) then {
 
 	// im Falle des Verkaufsbuttons -> Liste aller gefundenen Fahrzeuge
 	// alle Objekte im Radius von GVAR(saleRadius) Metern um das Pad -> im Idealfall nur das zu verkaufende Fahrzeug
-	_spawnpos = nearestObject [player, "Land_HelipadCircle_F"];
+	_spawnpos = nearestObject [player, "Land_HelipadEmpty_F"];
 	_objs = nearestObjects [_spawnpos, ["AllVehicles", "Thing"], GVAR(saleRadius)];
 
 	// gehe alle gefundenen Objekte durch und lösche sie, falls nicht in pool, oder ergänze um Verkaufspreis


### PR DESCRIPTION
In Mission und Scripts alle `Land_HelipadCircle_F` durch `Land_HelipadEmpty_F` ersetzt, damit die Helipads nicht mehr am Meeresgrund sichtbar sind.