### PR TITLE
BIS Gruppensystem wieder eingefügt

### DIFF
--- a/opt_mission.WL_Rosche/init.sqf
+++ b/opt_mission.WL_Rosche/init.sqf
@@ -5,3 +5,15 @@ enableSaving [false, false];
 waitUntil {!isNil "CLib_fnc_loadModules"};
 call CLib_fnc_loadModules;
 
+if (isServer) then 
+{
+
+    //Function that adds dynamic groups to the mission as seen in End Game
+    ["Initialize"] call BIS_fnc_dynamicGroups;
+};
+
+if (hasInterface) then 
+{
+    //Function that adds dynamic groups to the mission as seen in End Game
+    ["InitializePlayer", [player]] call BIS_fnc_dynamicGroups;
+};


### PR DESCRIPTION
Wie einfügen des Gruppensystem für den Dui Sqaud Radar.

Spieler sollen sich auf dem Squadradar sehen. Durch den wegfall der gruppen ist das kaputti gegangen #182

